### PR TITLE
Properly restore input focus after closing the menu on Windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### Fixed
 
+- Input focus after closing the menu on Windows. Now, the window which had focus before opening the menu will regain focus. Thanks to [@mmikeww](https://github.com/mmikeww) for this fix!
 - The transition of grandchild nodes in the menu. They are now smoothly faded in and out.
 
 ## [Kando 0.3.0](https://github.com/kando-menu/kando/releases/tag/v0.3.0)


### PR DESCRIPTION
This resolves #300.