### PR TITLE
:memo: Clarify manual install in "installing.md"

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -98,7 +98,7 @@ On GNOME under Wayland you will also need to install the [adapter extension](htt
 
 ### :rocket: Running the Prototype
 
-Once these dependencies are installed, only these two commands are required:
+Once these dependencies are installed, navigate into the Kando directory, then only these two commands are required:
 
 ```
 npm install


### PR DESCRIPTION
Very tiny change. I had some difficulty with not easily recognisable errors when running "npm install" to compile on macOS for the first time. After some tinkering I realised I needed to "cd /kando-directory-path" before running these commands which wasn't immediately obvious to me from the description. 

I think the reminder to cd into the Kando directory before running the two commands is helpful for those lacking experience like me who want to test new functionality by manually installing. 

I didn't make this change for windows and linux because I felt the lack of information is better than me giving incorrect information as I don't currently own a windows or linux machine to test installs there.