### PR TITLE
Suppot backends with no support for direct key bindings

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 - If binding a global shortcut fails, Kando will now show a desktop notification with an error message. Before, Kando would refuse to start.
 - It is now allowed to have multiple menus with the same shortcut. In this case, Kando will simply show the first menu with the given shortcut. In the future, there will be the possibility to select the menu based on the currently focused window.
+- The `"shortcut"` property in the menu configuration is now optional. If no shortcut is given, the menu will not be accessible via a global shortcut. This is useful if you want to have a menu which is only accessible via the tray icon.
 
 #### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,8 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### Added
 
-- The possibility to change the shortcut of a menu in the menu editor. There is now a text field in the properties area on the right-hand side which allows to either enter the shortcut directly or to press the key combination on the keyboard.
+- The possibility to change the shortcut of a menu in the menu editor. There is now a text field in the properties area on the right-hand side which allows to either enter the shortcut directly or to press the key combination on the keyboard. This works on all platforms, except for KDE/Wayland and Hyprland, where direct binding of global shortcuts is not directly supported.
+- The possibility to change the global shortcut ID on platforms which do not support direct binding of global shortcuts. For instance, on KDE/Wayland or on Hyprland, Kando can not directly bind global shortcuts. On those platforms, the menu editor shows a text field instead of the shortcut picker. Here you can enter a unique ID for the shortcut and then use the global shortcut settings of the desktop environment to bind the shortcut ID to a key combination.
 
 #### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### Added
 
 - The possibility to change the shortcut of a menu in the menu editor. There is now a text field in the properties area on the right-hand side which allows to either enter the shortcut directly or to press the key combination on the keyboard. This works on all platforms, except for KDE/Wayland and Hyprland, where direct binding of global shortcuts is not directly supported.
-- The possibility to change the global shortcut ID on platforms which do not support direct binding of global shortcuts. For instance, on KDE/Wayland or on Hyprland, Kando can not directly bind global shortcuts. On those platforms, the menu editor shows a text field instead of the shortcut picker. Here you can enter a unique ID for the shortcut and then use the global shortcut settings of the desktop environment to bind the shortcut ID to a key combination.
+- **[BREAKING]** The possibility to change the global shortcut ID on platforms which do not support direct binding of global shortcuts. For instance, on KDE/Wayland or on Hyprland, Kando can not directly bind global shortcuts. On those platforms, the menu editor shows a text field instead of the shortcut picker. Here you can enter a unique ID for the shortcut and then use the global shortcut settings of the desktop environment to bind the shortcut ID to a key combination. On these platforms, **your existing global shortcuts will not work anymore**. You will have to rebind them using the new method!
 
 #### Changed
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -67,7 +67,7 @@ They are JSON objects with the following properties:
 
 Property | Default Value | Description
 -------- | ------------- | -----------
-`shortcut` | _mandatory_ | The shortcut which opens the menu. This is a string which can contain multiple keys separated by `+`. For example, `"Ctrl+Shift+K"` or `"Cmd+Shift+K"`.
+`shortcutID` | `""` | On some platforms, Kando can not bind shortcuts directly. In this case, you can use this property to assign an ID which can be used in the global shortcut configuration of your desktop environment. This should be lowercase and contain only ASCII characters and dashes. For example, `"main-trigger"`.
 `nodes` | _mandatory_ | The root menu item of the menu given as a Menu Item Description. See below for details.
 `centered` | `false` | Whether the menu should be centered on the screen. If this is `false`, the menu will be opened at the position of the mouse cursor.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -67,6 +67,7 @@ They are JSON objects with the following properties:
 
 Property | Default Value | Description
 -------- | ------------- | -----------
+`shortcut` | `""` | The shortcut which opens the menu. This is a string which can contain multiple keys separated by `+`. For example, `"Ctrl+Shift+K"` or `"Cmd+Shift+K"`. If empty, the menu will not have a shortcut.
 `shortcutID` | `""` | On some platforms, Kando can not bind shortcuts directly. In this case, you can use this property to assign an ID which can be used in the global shortcut configuration of your desktop environment. This should be lowercase and contain only ASCII characters and dashes. For example, `"main-trigger"`.
 `nodes` | _mandatory_ | The root menu item of the menu given as a Menu Item Description. See below for details.
 `centered` | `false` | Whether the menu should be centered on the screen. If this is `false`, the menu will be opened at the position of the mouse cursor.

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -8,7 +8,14 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { IKeySequence, IVec2, IMenuItem, IAppSettings, IMenuSettings } from '../common';
+import {
+  IKeySequence,
+  IBackendInfo,
+  IVec2,
+  IMenuItem,
+  IAppSettings,
+  IMenuSettings,
+} from '../common';
 
 // Declare the API to the host process. See preload.ts for more information on the exposed
 // functions. The API has to be declared here again, because the TypeScript compiler
@@ -29,6 +36,7 @@ declare global {
         set: (data: IMenuSettings) => void;
         getCurrentMenu: () => Promise<number>;
       };
+      getBackendInfo: () => Promise<IBackendInfo>;
       unbindShortcuts: () => void;
       showDevTools: () => void;
       simulateKeys: (keys: IKeySequence) => void;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -31,11 +31,11 @@ export interface IBackendInfo {
   supportsShortcuts: boolean;
 
   /**
-   * This hint is shown in the editor when editing a menu. Use this to explain some quirks
-   * of the backend, such as how to change the shortcuts in the operating system if the
-   * backend does not support custom shortcuts.
+   * This hint is shown in the editor next to the shortcut-name input field if
+   * supportsShortcuts is false. It should briefly explain how to change the shortcuts in
+   * the operating system.
    */
-  editorHint: string;
+  shortcutHint: string;
 }
 
 /**

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -8,6 +8,36 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
+/** This interface describes some information about the currently used backend. */
+export interface IBackendInfo {
+  /**
+   * Each backend should return a suitable window type here. The window type determines
+   * how Kando's window is drawn. The most suitable type is dependent on the operating
+   * system and the window manager. For example, on GNOME, the window type "dock" seems to
+   * work best, on KDE "toolbar" provides a better experience. On Windows, "toolbar" is
+   * the only type that works.
+   * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions
+   *
+   * @returns The window type to use for the pie menu window.
+   */
+  windowType: string;
+
+  /**
+   * There are some backends which do not support custom shortcuts. In this case, the user
+   * will not be able to change the shortcuts in the settings. Usually, the hint returned
+   * by getEditorHint() which is shown in the settings dialog will explain how to change
+   * the shortcuts in the operating system.
+   */
+  supportsCustomShortcuts: boolean;
+
+  /**
+   * This hint is shown in the editor when editing a menu. Use this to explain some quirks
+   * of the backend, such as how to change the shortcuts in the operating system if the
+   * backend does not support custom shortcuts.
+   */
+  editorHint: string;
+}
+
 /**
  * A simple 2D vector.
  *

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -28,7 +28,7 @@ export interface IBackendInfo {
    * by getEditorHint() which is shown in the settings dialog will explain how to change
    * the shortcuts in the operating system.
    */
-  supportsCustomShortcuts: boolean;
+  supportsShortcuts: boolean;
 
   /**
    * This hint is shown in the editor when editing a menu. Use this to explain some quirks
@@ -113,8 +113,19 @@ export interface IMenu {
    */
   nodes: IMenuItem;
 
-  /** The shortcut to open the menu. */
+  /**
+   * The shortcut to open the menu. Something like 'Control+Space'.
+   *
+   * @todo: Add description of the format of the shortcut string.
+   */
   shortcut: string;
+
+  /**
+   * Some backends do not support direct binding of shortcuts. In this case, the user will
+   * not be able to change the shortcut in the settings. Instead, the user provides the
+   * name of the shortcut and can then assign a shortcut in the operating system.
+   */
+  shortcutName: string;
 
   /**
    * If true, the menu will open in the screen's center. Else it will open at the mouse

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -24,18 +24,18 @@ export interface IBackendInfo {
 
   /**
    * There are some backends which do not support custom shortcuts. In this case, the user
-   * will not be able to change the shortcuts in the settings. Usually, the hint returned
-   * by getEditorHint() which is shown in the settings dialog will explain how to change
-   * the shortcuts in the operating system.
+   * will not be able to change the shortcuts in the settings. Instead, the user will set
+   * a shortcut ID and then assign a shortcut in the operating system.
    */
   supportsShortcuts: boolean;
 
   /**
-   * This hint is shown in the editor next to the shortcut-name input field if
-   * supportsShortcuts is false. It should briefly explain how to change the shortcuts in
-   * the operating system.
+   * This hint is shown in the editor next to the shortcut-id input field if
+   * supportsShortcuts is false. It should very briefly explain how to change the
+   * shortcuts in the operating system. If supportsShortcuts is true, this is not
+   * required.
    */
-  shortcutHint: string;
+  shortcutHint?: string;
 }
 
 /**
@@ -122,10 +122,10 @@ export interface IMenu {
 
   /**
    * Some backends do not support direct binding of shortcuts. In this case, the user will
-   * not be able to change the shortcut in the settings. Instead, the user provides the
-   * name of the shortcut and can then assign a shortcut in the operating system.
+   * not be able to change the shortcut in the settings. Instead, the user provides an ID
+   * for the shortcut and can then assign a key binding in the operating system.
    */
-  shortcutName: string;
+  shortcutID: string;
 
   /**
    * If true, the menu will open in the screen's center. Else it will open at the mouse

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -300,6 +300,11 @@ export class KandoApp {
       return Math.max(index, 0);
     });
 
+    // Allow the renderer to retrieve information about the backend.
+    ipcMain.handle('get-backend-info', () => {
+      return this.backend.getBackendInfo();
+    });
+
     // Unbind all shortcuts. This is used when the menu editor is shown.
     ipcMain.on('unbind-shortcuts', async () => {
       await this.backend.unbindAllShortcuts();
@@ -618,6 +623,7 @@ export class KandoApp {
     return {
       nodes: root,
       shortcut: 'Control+Space',
+      shortcutName: 'prototype_menu',
       centered: false,
     };
   }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -231,7 +231,7 @@ export class KandoApp {
       y: display.workArea.y,
       width: display.workArea.width + 1,
       height: display.workArea.height + 1,
-      type: this.backend.getWindowType(),
+      type: this.backend.getBackendInfo().windowType,
       show: false,
     });
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -468,8 +468,12 @@ export class KandoApp {
 
     // Add an entry for each menu.
     for (const menu of this.menuSettings.get('menus')) {
+      const trigger =
+        (this.backend.getBackendInfo().supportsShortcuts
+          ? menu.shortcut
+          : menu.shortcutID) || 'Not Bound';
       template.push({
-        label: `${menu.nodes.name} (${menu.shortcut})`,
+        label: `${menu.nodes.name} (${trigger})`,
         click: () => this.showMenu(menu),
       });
     }

--- a/src/main/backends/backend.ts
+++ b/src/main/backends/backend.ts
@@ -8,7 +8,7 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { IKeySequence } from '../../common';
+import { IBackendInfo, IKeySequence } from '../../common';
 
 /**
  * This interface is used to transfer information required from the window manager when
@@ -55,16 +55,12 @@ export interface Backend {
   init: () => Promise<void>;
 
   /**
-   * Each backend should return a suitable window type here. The window type determines
-   * how the window is drawn. The most suitable type is dependent on the operating system
-   * and the window manager. For example, on GNOME, the window type "dock" seems to work
-   * best, on KDE "toolbar" provides a better experience. On Windows, "toolbar" is the
-   * only type that works.
-   * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions
+   * Each backend must provide some basic information about the backend. See IBackendInfo
+   * for more information.
    *
-   * @returns The window type to use for the pie menu window.
+   * @returns Some information about the backend.
    */
-  getWindowType: () => string;
+  getBackendInfo: () => IBackendInfo;
 
   /**
    * Each backend must provide a way to get the name and app of the currently focused

--- a/src/main/backends/backend.ts
+++ b/src/main/backends/backend.ts
@@ -26,15 +26,13 @@ export interface WMInfo {
 }
 
 /**
- * This interface is used to describe a keyboard shortcut. It contains a unique id, a
- * description and the actual shortcut. The shortcut is a string in the format used by
- * Electron's globalShortcut module. More information on the format can be found here:
- * https://www.electronjs.org/docs/latest/api/accelerator
+ * This interface is used to pass information about a keyboard shortcut to the backend. If
+ * the backend supports custom shortcuts, the trigger property contains the key sequence
+ * given by the user. Else, it will be the unique ID given by the user. The backend should
+ * use this ID to generate a global shortcut in the operating system.
  */
 export interface Shortcut {
-  id: string;
-  description: string;
-  accelerator: string;
+  trigger: string;
   action: () => void;
 }
 

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -35,7 +35,6 @@ export class GnomeBackend implements Backend {
     return {
       windowType: 'dock',
       supportsShortcuts: true,
-      shortcutHint: '',
     };
   }
 
@@ -130,11 +129,11 @@ export class GnomeBackend implements Backend {
    * shortcut is pressed. On GNOME Wayland, this uses the DBus interface of the Kando
    * GNOME Shell integration.
    *
-   * @param shortcut The shortcut to simulate.
+   * @param shortcut The shortcut to bind.
    * @returns A promise which resolves when the shortcut has been bound.
    */
   public async bindShortcut(shortcut: Shortcut) {
-    const accelerator = this.toGdkAccelerator(shortcut.accelerator);
+    const accelerator = this.toGdkAccelerator(shortcut.trigger);
 
     const success = await this.interface.BindShortcut(accelerator);
 
@@ -151,7 +150,7 @@ export class GnomeBackend implements Backend {
    * @param shortcut The shortcut to unbind.
    */
   public async unbindShortcut(shortcut: Shortcut) {
-    const accelerator = this.toGdkAccelerator(shortcut.accelerator);
+    const accelerator = this.toGdkAccelerator(shortcut.trigger);
 
     const success = await this.interface.UnbindShortcut(accelerator);
 

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -168,7 +168,10 @@ export class GnomeBackend implements Backend {
   }
 
   /**
-   * Translates a shortcut from the Electron format to the GDK format.
+   * Translates a shortcut from the Electron format to the GDK format. The Electron format
+   * is described here: https://www.electronjs.org/docs/latest/api/accelerator Gdk uses
+   * the key names from this file (simply without the GDK_KEY_ prefix):
+   * https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdkkeysyms.h
    *
    * @param shortcut The shortcut to translate.
    * @returns The translated shortcut.
@@ -183,17 +186,83 @@ export class GnomeBackend implements Backend {
       throw new Error('Shortcuts including AltGr are not yet supported on GNOME.');
     }
 
-    shortcut = shortcut.replace('CommandOrControl+', '<Ctrl>');
-    shortcut = shortcut.replace('CmdOrCtrl+', '<Ctrl>');
-    shortcut = shortcut.replace('Command+', '<Ctrl>');
-    shortcut = shortcut.replace('Control+', '<Ctrl>');
-    shortcut = shortcut.replace('Cmd+', '<Ctrl>');
-    shortcut = shortcut.replace('Ctrl+', '<Ctrl>');
-    shortcut = shortcut.replace('Alt+', '<Alt>');
-    shortcut = shortcut.replace('Shift+', '<Shift>');
-    shortcut = shortcut.replace('Meta+', '<Meta>');
-    shortcut = shortcut.replace('Super+', '<Super>');
+    // Split the shortcut into its parts.
+    const parts = shortcut.split('+');
 
-    return shortcut;
+    const replacements = new Map([
+      ['CommandOrControl', '<Ctrl>'],
+      ['CmdOrCtrl', '<Ctrl>'],
+      ['Command', '<Ctrl>'],
+      ['Control', '<Ctrl>'],
+      ['Cmd', '<Ctrl>'],
+      ['Ctrl', '<Ctrl>'],
+      ['Alt', '<Alt>'],
+      ['Shift', '<Shift>'],
+      ['Meta', '<Meta>'],
+      ['Super', '<Super>'],
+      [')', 'parenright'],
+      ['!', 'exclam'],
+      ['@', 'at'],
+      ['#', 'numbersign'],
+      ['$', 'dollar'],
+      ['%', 'percent'],
+      ['^', 'asciicircum'],
+      ['&', 'ampersand'],
+      ['*', 'asterisk'],
+      ['(', 'parenleft'],
+      [':', 'colon'],
+      [';', 'semicolon'],
+      ["'", 'apostrophe'],
+      ['=', 'equal'],
+      ['<', 'less'],
+      [',', 'comma'],
+      ['_', 'underscore'],
+      ['-', 'minus'],
+      ['>', 'greater'],
+      ['.', 'period'],
+      ['?', 'question'],
+      ['/', 'slash'],
+      ['~', 'asciitilde'],
+      ['`', 'grave'],
+      ['{', 'braceleft'],
+      [']', 'bracketright'],
+      ['[', 'bracketleft'],
+      ['|', 'bar'],
+      ['\\', 'backslash'],
+      ['}', 'braceright'],
+      ['"', 'quotedbl'],
+      ['Capslock', 'Caps_lock'],
+      ['Numlock', 'Num_lock'],
+      ['Scrolllock', 'Scroll_lock'],
+      ['Enter', 'Return'],
+      ['PageUp', 'Page_Up'],
+      ['PageDown', 'PageDo_wn'],
+      ['Esc', 'Escape'],
+      ['VolumeUp', 'AudioRaiseVolume'],
+      ['VolumeDown', 'AudioLowerVolume'],
+      ['VolumeMute', 'AudioMute'],
+      ['MediaNextTrack', 'AudioNext'],
+      ['MediaPreviousTrack', 'AudioPrev'],
+      ['MediaStop', 'AudioStop'],
+      ['MediaPlayPause', 'AudioPause'],
+      ['PrintScreen', 'Print'],
+      ['num0', 'KP_0'],
+      ['num1', 'KP_1'],
+      ['num2', 'KP_2'],
+      ['num3', 'KP_3'],
+      ['num4', 'KP_4'],
+      ['num5', 'KP_5'],
+      ['num6', 'KP_6'],
+      ['num7', 'KP_7'],
+      ['num8', 'KP_8'],
+      ['num9', 'KP_9'],
+      ['numdec', 'KP_Decimal'],
+      ['numadd', 'KP_Add'],
+      ['numsub', 'KP_Subtract'],
+      ['nummult', 'KP_Multiply'],
+      ['numdiv', 'KP_Divide'],
+    ]);
+
+    return parts.map((part) => replacements.get(part) || part).join('');
   }
 }

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -197,7 +197,7 @@ export class GnomeBackend implements Backend {
       ['Ctrl', '<Ctrl>'],
       ['Alt', '<Alt>'],
       ['Shift', '<Shift>'],
-      ['Meta', '<Meta>'],
+      ['Meta', '<Super>'],
       ['Super', '<Super>'],
       [')', 'parenright'],
       ['!', 'exclam'],

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -30,11 +30,13 @@ export class GnomeBackend implements Backend {
    * Dock On GNOME Shell, we use a dock window. This creates a floating window which is
    * always on top of all other windows. It even stays visible during workspace
    * switching.
-   *
-   * @returns 'dock'
    */
-  public getWindowType() {
-    return 'dock';
+  public getBackendInfo() {
+    return {
+      windowType: 'dock',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /**

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -35,7 +35,7 @@ export class GnomeBackend implements Backend {
     return {
       windowType: 'dock',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -34,7 +34,7 @@ export class GnomeBackend implements Backend {
   public getBackendInfo() {
     return {
       windowType: 'dock',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -42,7 +42,7 @@ for more information.
     return {
       windowType: 'splash',
       supportsShortcuts: false,
-      shortcutHint: 'Use your hypr.conf to bind this.',
+      shortcutHint: 'Use your hyprland.conf to bind this.',
     };
   }
 

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -37,11 +37,13 @@ for more information.
   /**
    * 'splash' seems to be a good choice for Hyprland. See:
    * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions
-   *
-   * @returns 'splash'
    */
-  public getWindowType() {
-    return 'splash';
+  public getBackendInfo() {
+    return {
+      windowType: 'splash',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /**

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -42,7 +42,7 @@ for more information.
     return {
       windowType: 'splash',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -41,8 +41,8 @@ for more information.
   public getBackendInfo() {
     return {
       windowType: 'splash',
-      supportsShortcuts: true,
-      shortcutHint: '',
+      supportsShortcuts: false,
+      shortcutHint: 'Use your hypr.conf to bind this.',
     };
   }
 
@@ -73,7 +73,7 @@ for more information.
    * This binds a shortcut. The action callback of the shortcut is called when the
    * shortcut is pressed.
    *
-   * @param shortcut The shortcut to simulate.
+   * @param shortcut The shortcut to bind.
    */
   public async bindShortcut(shortcut: Shortcut) {
     native.bindShortcut(shortcut);

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -41,7 +41,7 @@ for more information.
   public getBackendInfo() {
     return {
       windowType: 'splash',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/linux/hyprland/native/Native.cpp
+++ b/src/main/backends/linux/hyprland/native/Native.cpp
@@ -134,14 +134,17 @@ void Native::bindShortcut(const Napi::CallbackInfo& info) {
 
   // Get the shortcut data from the JavaScript object. We store the action function in a
   // Napi::Persistent object to make sure that it is not garbage collected.
-  std::string id          = info[0].As<Napi::Object>().Get("id").ToString();
-  std::string description = info[0].As<Napi::Object>().Get("description").ToString();
+  std::string id = info[0].As<Napi::Object>().Get("trigger").ToString();
   mShortcuts[id].mAction =
       Napi::Persistent(info[0].As<Napi::Object>().Get("action").As<Napi::Function>());
 
+  // Transform id to lowercase and replace all whitespace with '-'.
+  std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+  std::replace(id.begin(), id.end(), ' ', '-');
+
   // Register the shortcut with the Wayland display.
   auto shortcut = hyprland_global_shortcuts_manager_v1_register_shortcut(
-      mData.mManager, id.c_str(), "kando", description.c_str(), "");
+      mData.mManager, id.c_str(), "kando", "Kando", "");
 
   // Add the callback functions to the shortcut.
   hyprland_global_shortcut_v1_add_listener(shortcut, &mData.mShortcutListener, nullptr);

--- a/src/main/backends/linux/hyprland/native/Native.cpp
+++ b/src/main/backends/linux/hyprland/native/Native.cpp
@@ -138,10 +138,6 @@ void Native::bindShortcut(const Napi::CallbackInfo& info) {
   mShortcuts[id].mAction =
       Napi::Persistent(info[0].As<Napi::Object>().Get("action").As<Napi::Function>());
 
-  // Transform id to lowercase and replace all whitespace with '-'.
-  std::transform(id.begin(), id.end(), id.begin(), ::tolower);
-  std::replace(id.begin(), id.end(), ' ', '-');
-
   // Register the shortcut with the Wayland display.
   auto shortcut = hyprland_global_shortcuts_manager_v1_register_shortcut(
       mData.mManager, id.c_str(), "kando", "Kando", "");
@@ -209,13 +205,11 @@ void Native::unbindAllShortcuts(const Napi::CallbackInfo& info) {
 
 bool Native::isShortcutObject(Napi::Object const& obj) const {
 
-  if (!obj.Has("id") || !obj.Has("description") || !obj.Has("accelerator") ||
-      !obj.Has("action")) {
+  if (!obj.Has("trigger") || !obj.Has("action")) {
     return false;
   }
 
-  if (!obj.Get("id").IsString() || !obj.Get("description").IsString() ||
-      !obj.Get("accelerator").IsString() || !obj.Get("action").IsFunction()) {
+  if (!obj.Get("trigger").IsString() || !obj.Get("action").IsFunction()) {
     return false;
   }
 

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -81,11 +81,13 @@ export class KDEWaylandBackend implements Backend {
   /**
    * On KDE, the 'toolbar' window type is used. The 'dock' window type makes the window
    * not receive any keyboard events.
-   *
-   * @returns 'toolbar'
    */
-  public getWindowType() {
-    return 'toolbar';
+  public getBackendInfo() {
+    return {
+      windowType: 'toolbar',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /**

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -273,7 +273,7 @@ export class KDEWaylandBackend implements Backend {
         const id = this.escapeString(shortcut.trigger);
 
         return `
-          if(registerShortcut('${id}', 'Kando', '',
+          if(registerShortcut('${id}', 'Kando - ${id}', '',
             () => {
               console.log('Kando: Triggered.');
               callDBus('org.kandomenu.kando', '/org/kandomenu/kando',

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -85,7 +85,7 @@ export class KDEWaylandBackend implements Backend {
   public getBackendInfo() {
     return {
       windowType: 'toolbar',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -86,7 +86,7 @@ export class KDEWaylandBackend implements Backend {
     return {
       windowType: 'toolbar',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/main/backends/linux/kde/x11/backend.ts
+++ b/src/main/backends/linux/kde/x11/backend.ts
@@ -15,10 +15,10 @@ export class KDEX11Backend extends X11Backend {
   /**
    * On KDE, the 'toolbar' window type is used. The 'dock' window type makes the window
    * not receive any keyboard events.
-   *
-   * @returns 'toolbar'
    */
-  public override getWindowType() {
-    return 'toolbar';
+  public getBackendInfo() {
+    const info = super.getBackendInfo();
+    info.windowType = 'toolbar';
+    return info;
   }
 }

--- a/src/main/backends/linux/wlroots/backend.ts
+++ b/src/main/backends/linux/wlroots/backend.ts
@@ -10,7 +10,7 @@
 
 import { native } from './native';
 import { Backend, Shortcut, WMInfo } from '../../backend';
-import { IKeySequence } from '../../../../common';
+import { IBackendInfo, IKeySequence } from '../../../../common';
 import { LinuxKeyCodes } from '../keys';
 
 /**
@@ -73,7 +73,7 @@ export abstract class WLRBackend implements Backend {
   // These methods are abstract and need to be implemented by subclasses. See the docs
   // of the methods in the Backend interface for more information.
   abstract init(): Promise<void>;
-  abstract getWindowType(): string;
+  abstract getBackendInfo(): IBackendInfo;
   abstract getWMInfo(): Promise<WMInfo>;
   abstract bindShortcut(shortcut: Shortcut): Promise<void>;
   abstract unbindShortcut(shortcut: Shortcut): Promise<void>;

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -26,11 +26,13 @@ export class X11Backend implements Backend {
   /**
    * Override this if another type is more suitable for your desktop environment.
    * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions
-   *
-   * @returns 'dock'
    */
-  public getWindowType() {
-    return 'dock';
+  public getBackendInfo() {
+    return {
+      windowType: 'dock',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /** This is called when the backend is created. Currently, this this does nothing on X11. */

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -31,7 +31,6 @@ export class X11Backend implements Backend {
     return {
       windowType: 'dock',
       supportsShortcuts: true,
-      shortcutHint: '',
     };
   }
 
@@ -107,11 +106,11 @@ export class X11Backend implements Backend {
    * This binds a shortcut. The action callback of the shortcut is called when the
    * shortcut is pressed. On X11, this uses Electron's globalShortcut module.
    *
-   * @param shortcut The shortcut to simulate.
+   * @param shortcut The shortcut to bind.
    * @returns A promise which resolves when the shortcut has been bound.
    */
   public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.accelerator, shortcut.action)) {
+    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
       throw new Error('Invalid shortcut or it is already in use.');
     }
   }
@@ -122,7 +121,7 @@ export class X11Backend implements Backend {
    * @param shortcut The shortcut to unbind.
    */
   public async unbindShortcut(shortcut: Shortcut) {
-    globalShortcut.unregister(shortcut.accelerator);
+    globalShortcut.unregister(shortcut.trigger);
   }
 
   /** This unbinds all previously bound shortcuts. */

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -30,7 +30,7 @@ export class X11Backend implements Backend {
   public getBackendInfo() {
     return {
       windowType: 'dock',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -31,7 +31,7 @@ export class X11Backend implements Backend {
     return {
       windowType: 'dock',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/main/backends/macos/backend.ts
+++ b/src/main/backends/macos/backend.ts
@@ -23,7 +23,7 @@ export class MacosBackend implements Backend {
     return {
       windowType: 'panel',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/main/backends/macos/backend.ts
+++ b/src/main/backends/macos/backend.ts
@@ -18,11 +18,13 @@ export class MacosBackend implements Backend {
   /**
    * On macOS, the window type is set to 'panel'. This makes sure that the window is
    * always on top of other windows and that it is shown on all workspaces.
-   *
-   * @returns 'panel'
    */
-  public getWindowType() {
-    return 'panel';
+  public getBackendInfo() {
+    return {
+      windowType: 'panel',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /** On macOS, we use this to hide the dock icon. */

--- a/src/main/backends/macos/backend.ts
+++ b/src/main/backends/macos/backend.ts
@@ -23,7 +23,6 @@ export class MacosBackend implements Backend {
     return {
       windowType: 'panel',
       supportsShortcuts: true,
-      shortcutHint: '',
     };
   }
 
@@ -106,7 +105,7 @@ export class MacosBackend implements Backend {
    * @returns A promise which resolves when the shortcut has been bound.
    */
   public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.accelerator, shortcut.action)) {
+    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
       throw new Error('Invalid shortcut or it is already in use.');
     }
   }
@@ -117,7 +116,7 @@ export class MacosBackend implements Backend {
    * @param shortcut The shortcut to unbind.
    */
   public async unbindShortcut(shortcut: Shortcut) {
-    globalShortcut.unregister(shortcut.accelerator);
+    globalShortcut.unregister(shortcut.trigger);
   }
 
   /** This unbinds all previously bound shortcuts. */

--- a/src/main/backends/macos/backend.ts
+++ b/src/main/backends/macos/backend.ts
@@ -22,7 +22,7 @@ export class MacosBackend implements Backend {
   public getBackendInfo() {
     return {
       windowType: 'panel',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/windows/backend.ts
+++ b/src/main/backends/windows/backend.ts
@@ -27,7 +27,6 @@ export class WindowsBackend implements Backend {
     return {
       windowType: 'toolbar',
       supportsShortcuts: true,
-      shortcutHint: '',
     };
   }
 
@@ -109,7 +108,7 @@ export class WindowsBackend implements Backend {
    * @returns A promise which resolves when the shortcut has been bound.
    */
   public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.accelerator, shortcut.action)) {
+    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
       throw new Error('Invalid shortcut or it is already in use.');
     }
   }
@@ -120,7 +119,7 @@ export class WindowsBackend implements Backend {
    * @param shortcut The shortcut to unbind.
    */
   public async unbindShortcut(shortcut: Shortcut) {
-    globalShortcut.unregister(shortcut.accelerator);
+    globalShortcut.unregister(shortcut.trigger);
   }
 
   /** This unbinds all previously bound shortcuts. */

--- a/src/main/backends/windows/backend.ts
+++ b/src/main/backends/windows/backend.ts
@@ -26,7 +26,7 @@ export class WindowsBackend implements Backend {
   public getBackendInfo() {
     return {
       windowType: 'toolbar',
-      supportsCustomShortcuts: true,
+      supportsShortcuts: true,
       editorHint: '',
     };
   }

--- a/src/main/backends/windows/backend.ts
+++ b/src/main/backends/windows/backend.ts
@@ -22,11 +22,13 @@ export class WindowsBackend implements Backend {
   /**
    * On Windows, the 'toolbar' window type is used. This is actually the only window type
    * supported by Electron on Windows.
-   *
-   * @returns 'toolbar'
    */
-  public getWindowType() {
-    return 'toolbar';
+  public getBackendInfo() {
+    return {
+      windowType: 'toolbar',
+      supportsCustomShortcuts: true,
+      editorHint: '',
+    };
   }
 
   /**

--- a/src/main/backends/windows/backend.ts
+++ b/src/main/backends/windows/backend.ts
@@ -27,7 +27,7 @@ export class WindowsBackend implements Backend {
     return {
       windowType: 'toolbar',
       supportsShortcuts: true,
-      editorHint: '',
+      shortcutHint: '',
     };
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -20,66 +20,68 @@ import { Editor } from './renderer/editor/editor';
 
 // Wire up the menu and the editor -------------------------------------------------------
 
-const menu = new Menu(document.getElementById('kando-menu'));
-const editor = new Editor(document.getElementById('kando-editor'));
+window.api.getBackendInfo().then((info) => {
+  const menu = new Menu(document.getElementById('kando-menu'));
+  const editor = new Editor(document.getElementById('kando-editor'), info);
 
-// Show the menu when the main process requests it.
-window.api.showMenu((root, pos) => {
-  menu.show(root, pos);
-  editor.show();
-});
+  // Show the menu when the main process requests it.
+  window.api.showMenu((root, pos) => {
+    menu.show(root, pos);
+    editor.show();
+  });
 
-// Show the editor when the main process requests it.
-window.api.showEditor(() => {
-  editor.show();
-  editor.enterEditMode();
-});
+  // Show the editor when the main process requests it.
+  window.api.showEditor(() => {
+    editor.show();
+    editor.enterEditMode();
+  });
 
-// Sometimes, the user may select an item too close to the edge of the screen. In this
-// case, we can not open the menu directly under the pointer. To make sure that the
-// menu is still exactly under the pointer, we move the pointer a little bit.
-menu.on('move-pointer', (dist) => {
-  window.api.movePointer(dist);
-});
+  // Sometimes, the user may select an item too close to the edge of the screen. In this
+  // case, we can not open the menu directly under the pointer. To make sure that the
+  // menu is still exactly under the pointer, we move the pointer a little bit.
+  menu.on('move-pointer', (dist) => {
+    window.api.movePointer(dist);
+  });
 
-// Hide Kando's window when the user aborts a selection.
-menu.on('cancel', () => {
-  menu.hide();
-  editor.hide();
-  window.api.cancelSelection();
-});
-
-// Hide Kando's window when the user selects an item and notify the main process.
-menu.on('select', (path) => {
-  menu.hide();
-  editor.hide();
-  window.api.selectItem(path);
-});
-
-// Report hover and unhover events to the main process.
-menu.on('hover', (path) => window.api.hoverItem(path));
-menu.on('unhover', (path) => window.api.unhoverItem(path));
-
-// Hide the menu when the user enters edit mode.
-editor.on('enter-edit-mode', () => {
-  menu.hide();
-});
-
-// Hide Kando's window when the user leaves edit mode.
-editor.on('leave-edit-mode', () => {
-  editor.hide();
-  window.api.cancelSelection();
-});
-
-// Hide the menu or the editor when the user presses escape.
-document.body.addEventListener('keydown', (ev) => {
-  if (ev.key === 'Escape') {
+  // Hide Kando's window when the user aborts a selection.
+  menu.on('cancel', () => {
     menu.hide();
     editor.hide();
     window.api.cancelSelection();
-  }
-});
+  });
 
-// This is helpful during development as it shows us when the renderer process has
-// finished reloading.
-window.api.log("Successfully loaded Kando's renderer process.");
+  // Hide Kando's window when the user selects an item and notify the main process.
+  menu.on('select', (path) => {
+    menu.hide();
+    editor.hide();
+    window.api.selectItem(path);
+  });
+
+  // Report hover and unhover events to the main process.
+  menu.on('hover', (path) => window.api.hoverItem(path));
+  menu.on('unhover', (path) => window.api.unhoverItem(path));
+
+  // Hide the menu when the user enters edit mode.
+  editor.on('enter-edit-mode', () => {
+    menu.hide();
+  });
+
+  // Hide Kando's window when the user leaves edit mode.
+  editor.on('leave-edit-mode', () => {
+    editor.hide();
+    window.api.cancelSelection();
+  });
+
+  // Hide the menu or the editor when the user presses escape.
+  document.body.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape') {
+      menu.hide();
+      editor.hide();
+      window.api.cancelSelection();
+    }
+  });
+
+  // This is helpful during development as it shows us when the renderer process has
+  // finished reloading.
+  window.api.log("Successfully loaded Kando's renderer process.");
+});

--- a/src/renderer/editor/editor.scss
+++ b/src/renderer/editor/editor.scss
@@ -166,4 +166,18 @@
   .tooltip {
     --bs-tooltip-bg: rgba(220, 220, 220, 0.99);
   }
+
+  // These are shown in various places in the editor.
+  .swirl {
+    display: inline-block;
+    background-image: url(../../assets/images/swirl.svg);
+    width: 160px;
+    height: 14px;
+
+    &.vertical {
+      width: 14px;
+      height: 160px;
+      background-image: url(../../assets/images/swirl-vertical.svg);
+    }
+  }
 }

--- a/src/renderer/editor/editor.ts
+++ b/src/renderer/editor/editor.ts
@@ -205,7 +205,7 @@ export class Editor extends EventEmitter {
           children: [],
         },
         shortcut: '',
-        shortcutName: '',
+        shortcutID: '',
         centered: false,
       };
 

--- a/src/renderer/editor/properties/properties.scss
+++ b/src/renderer/editor/properties/properties.scss
@@ -88,11 +88,14 @@
 
   #kando-menu-properties-menu-settings {
     max-height: 220px;
-    transition: max-height 150ms ease-in-out;
-    overflow: hidden;
+    transition:
+      max-height 150ms ease-in-out,
+      opacity 150ms ease;
+    overflow: visible clip;
 
     &.hidden {
       max-height: 0;
+      opacity: 0;
     }
   }
 }

--- a/src/renderer/editor/properties/properties.ts
+++ b/src/renderer/editor/properties/properties.ts
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 import Handlebars from 'handlebars';
 
 import { IEditorMenuItem } from '../common/editor-menu-item';
-import { IMenu } from '../../../common';
+import { IMenu, IBackendInfo } from '../../../common';
 import { IconPicker } from './icon-picker';
 import { IconThemeRegistry } from '../../../common/icon-theme-registry';
 import { ShortcutPicker } from './shortcut-picker';
@@ -85,14 +85,22 @@ export class Properties extends EventEmitter {
   /**
    * This constructor creates the HTML elements for the menu properties view and wires up
    * all the functionality.
+   *
+   * @param backend The backend info is used to determine whether the menu properties view
+   *   should show a 'Shortcut' label or a 'Shortcut Name' label.
    */
-  constructor() {
+  constructor(backend: IBackendInfo) {
     super();
 
     const template = Handlebars.compile(require('./templates/properties.hbs').default);
 
     const div = document.createElement('div');
-    div.innerHTML = template({});
+    div.innerHTML = template({
+      shortcutLabel: backend.supportsShortcuts ? 'Shortcut' : 'Shortcut Name',
+      shortcutHint: backend.supportsShortcuts
+        ? 'This will open the menu.'
+        : backend.shortcutHint,
+    });
 
     // The first child of the div is the container.
     this.container = div.firstElementChild as HTMLElement;
@@ -187,11 +195,8 @@ export class Properties extends EventEmitter {
    * Make this Properties view display the properties of the given menu.
    *
    * @param menu The menu whose properties should be displayed.
-   * @param supportsShortcuts If true, the user can directly change the shortcut of the
-   *   menu. Else the user can change the name of the shortcut but not the shortcut
-   *   itself.
    */
-  public setMenu(menu: IMenu, supportsShortcuts: boolean) {
+  public setMenu(menu: IMenu) {
     // This will update the name input and the icon button.
     this.setItem(menu.nodes);
 

--- a/src/renderer/editor/properties/properties.ts
+++ b/src/renderer/editor/properties/properties.ts
@@ -187,8 +187,11 @@ export class Properties extends EventEmitter {
    * Make this Properties view display the properties of the given menu.
    *
    * @param menu The menu whose properties should be displayed.
+   * @param supportsShortcuts If true, the user can directly change the shortcut of the
+   *   menu. Else the user can change the name of the shortcut but not the shortcut
+   *   itself.
    */
-  public setMenu(menu: IMenu) {
+  public setMenu(menu: IMenu, supportsShortcuts: boolean) {
     // This will update the name input and the icon button.
     this.setItem(menu.nodes);
 

--- a/src/renderer/editor/properties/shortcut-id-picker.ts
+++ b/src/renderer/editor/properties/shortcut-id-picker.ts
@@ -1,0 +1,84 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import Handlebars from 'handlebars';
+import { EventEmitter } from 'events';
+
+/**
+ * This shortcut picker is used if the backend does not support custom shortcuts but only
+ * global bindings which need to be set in the operation system settings.
+ *
+ * The picker only accepts lowercase ascii characters and no whitespace.
+ *
+ * @fires changed - When the user selects a new valid shortcut ID. The event contains the
+ *   new ID as an argument.
+ */
+export class ShortcutIDPicker extends EventEmitter {
+  /** The input field for editing the ID. */
+  private input: HTMLInputElement = null;
+
+  /**
+   * Creates a new ShortcutIDPicker and appends it to the given container.
+   *
+   * @param container - The container to which the icon picker will be appended.
+   */
+  constructor(container: HTMLElement) {
+    super();
+
+    // Render the template.
+    const template = Handlebars.compile(
+      require('./templates/shortcut-picker.hbs').default
+    );
+    container.innerHTML = template({
+      placeholder: 'Not Bound',
+      withButton: false,
+    });
+
+    // Validate the input field when the user types something. If the input is valid, we
+    // emit a 'changed' event.
+    this.input = container.querySelector('input');
+    this.input.addEventListener('input', () => {
+      const start = this.input.selectionStart;
+      const end = this.input.selectionEnd;
+
+      const shortcut = this.normalizeShortcut(this.input.value);
+      this.input.value = shortcut;
+      this.emit('changed', this.input.value);
+
+      // We restore the cursor position.
+      this.input.setSelectionRange(start, end);
+    });
+  }
+
+  /**
+   * This method sets the shortcut ID. The shortcut is normalized before it is set.
+   *
+   * @param id The id to set.
+   */
+  public setValue(id: string) {
+    id = this.normalizeShortcut(id);
+    this.input.value = id;
+  }
+
+  /**
+   * This method normalizes the given shortcut ID. It replaces all whitespace with '-' and
+   * transforms it to lowercase. All non-ascii characters are removed.
+   *
+   * @param id The shortcut ID to normalize.
+   * @returns The normalized shortcut ID.
+   */
+  private normalizeShortcut(id: string) {
+    // We first remove any whitespace and transform the shortcut to lowercase.
+    id = id.replace(/\s/g, '-').toLowerCase();
+
+    // We only allow lowercase ascii characters.
+    return id.replace(/[^a-z0-9-]/g, '');
+  }
+}

--- a/src/renderer/editor/properties/shortcut-picker.ts
+++ b/src/renderer/editor/properties/shortcut-picker.ts
@@ -57,6 +57,7 @@ export class ShortcutPicker extends EventEmitter {
     );
     container.innerHTML = template({
       placeholder: 'Not Bound',
+      withButton: true,
     });
 
     // Validate the input field when the user types something. If the input is valid, we

--- a/src/renderer/editor/properties/shortcut-picker.ts
+++ b/src/renderer/editor/properties/shortcut-picker.ts
@@ -145,7 +145,7 @@ export class ShortcutPicker extends EventEmitter {
    *
    * @param shortcut The shortcut to set.
    */
-  public setShortcut(shortcut: string) {
+  public setValue(shortcut: string) {
     shortcut = this.normalizeShortcut(shortcut);
     this.shortcutInput.value = shortcut;
     if (this.isValidShortcut(shortcut)) {

--- a/src/renderer/editor/properties/templates/properties.hbs
+++ b/src/renderer/editor/properties/templates/properties.hbs
@@ -40,7 +40,7 @@
             {{shortcutHint}}
           </div>
         </div>
-        <div id="kando-menu-properties-shortcut-picker" class="flex-grow-1 align-self-center"></div>
+        <div id="kando-menu-properties-shortcut-picker" class="align-self-center" style="flex-grow: 2;"></div>
       </div>
     </div>
 

--- a/src/renderer/editor/properties/templates/properties.hbs
+++ b/src/renderer/editor/properties/templates/properties.hbs
@@ -34,27 +34,14 @@
       <div class='d-flex mt-3'>
         <div class="flex-grow-1">
           <div class='kando-font fs-2'>
-            Shortcut
+            {{shortcutLabel}}
           </div>
           <div class='kando-font fs-5'>
-            This will open the menu.
+            {{shortcutHint}}
           </div>
         </div>
         <div id="kando-menu-properties-shortcut-picker" class="flex-grow-1 align-self-center"></div>
       </div>
-
-    </div>
-
-    <div class='d-flex flex-column justify-content-center wip my-3' style="height: 20vh;">
-      <div class='text-center kando-font fs-2'>
-        Here will be more settings.
-      </div>
-      <div class='text-center kando-font fs-5'>
-        Stay tuned for future updates!
-      </div>
-        <div class='text-center mb-4'>
-         <span class='swirl'></span>
-       </div>
     </div>
 
   </div>

--- a/src/renderer/editor/properties/templates/shortcut-picker.hbs
+++ b/src/renderer/editor/properties/templates/shortcut-picker.hbs
@@ -10,6 +10,8 @@
 }}
 
 <div class="shortcut-picker input-group">
-  <input type="text" class="form-control fs-3 kando-font" placeholder="{{placeholder}}" size="10">
-  <button class="btn btn-primary fs-3"><i class='material-symbols-rounded inline-icon'>keyboard</i></button>
+  <input type="text" class="form-control fs-3 kando-font" placeholder="{{placeholder}}" size="1">
+  {{#if withButton}}
+    <button class="btn btn-primary fs-3"><i class='material-symbols-rounded inline-icon'>keyboard</i></button>
+  {{/if}}
 </div>

--- a/src/renderer/editor/toolbar/menus-tab.ts
+++ b/src/renderer/editor/toolbar/menus-tab.ts
@@ -86,8 +86,10 @@ export class MenusTab extends EventEmitter {
    *
    * @param menus A list of menus.
    * @param currentMenu The index of the currently selected menu.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  public setMenus(menus: Array<IMenu>, currentMenu: number) {
+  public setMenus(menus: Array<IMenu>, currentMenu: number, showShortcuts: boolean) {
     this.dragger.removeAllDraggables();
 
     const template = Handlebars.compile(require('./templates/menus-tab.hbs').default);
@@ -96,7 +98,7 @@ export class MenusTab extends EventEmitter {
     const data = menus.map((menu, index) => ({
       name: menu.nodes.name,
       active: index === currentMenu,
-      description: menu.shortcut || 'Not bound.',
+      description: (showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
       icon: IconThemeRegistry.getInstance()
         .getTheme(menu.nodes.iconTheme)
         .createDiv(menu.nodes.icon).outerHTML,

--- a/src/renderer/editor/toolbar/menus-tab.ts
+++ b/src/renderer/editor/toolbar/menus-tab.ts
@@ -27,6 +27,12 @@ export class MenusTab extends EventEmitter {
   /** The container is the HTML element which contains the entire toolbar. */
   private container: HTMLElement = null;
 
+  /**
+   * If true, menu buttons will show the shortcuts, else they will show the shortcut
+   * names.
+   */
+  private showShortcuts: boolean = false;
+
   /** This is the HTML element which contains the menus tab's content. */
   private tab: HTMLElement = null;
 
@@ -44,13 +50,18 @@ export class MenusTab extends EventEmitter {
    * This constructor is called after the general toolbar DOM has been created.
    *
    * @param container The container is the HTML element which contains the entire toolbar.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, showShortcuts: boolean) {
     super();
 
     // Store a reference to the container. We will attach menu buttons divs to it during
     // drag'n'drop operations.
     this.container = container;
+
+    // Store the showShortcuts argument.
+    this.showShortcuts = showShortcuts;
 
     // Store a reference to the trash tab. This is the only drop target for dragged menus.
     this.trashTab = this.container.querySelector(
@@ -86,10 +97,8 @@ export class MenusTab extends EventEmitter {
    *
    * @param menus A list of menus.
    * @param currentMenu The index of the currently selected menu.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
    */
-  public setMenus(menus: Array<IMenu>, currentMenu: number, showShortcuts: boolean) {
+  public setMenus(menus: Array<IMenu>, currentMenu: number) {
     this.dragger.removeAllDraggables();
 
     const template = Handlebars.compile(require('./templates/menus-tab.hbs').default);
@@ -98,7 +107,8 @@ export class MenusTab extends EventEmitter {
     const data = menus.map((menu, index) => ({
       name: menu.nodes.name,
       active: index === currentMenu,
-      description: (showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
+      description:
+        (this.showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
       icon: IconThemeRegistry.getInstance()
         .getTheme(menu.nodes.iconTheme)
         .createDiv(menu.nodes.icon).outerHTML,

--- a/src/renderer/editor/toolbar/menus-tab.ts
+++ b/src/renderer/editor/toolbar/menus-tab.ts
@@ -27,11 +27,8 @@ export class MenusTab extends EventEmitter {
   /** The container is the HTML element which contains the entire toolbar. */
   private container: HTMLElement = null;
 
-  /**
-   * If true, menu buttons will show the shortcuts, else they will show the shortcut
-   * names.
-   */
-  private showShortcuts: boolean = false;
+  /** If true, menu buttons will show the shortcut IDs, instead of the shortcuts. */
+  private showShortcutIDs: boolean = false;
 
   /** This is the HTML element which contains the menus tab's content. */
   private tab: HTMLElement = null;
@@ -50,18 +47,18 @@ export class MenusTab extends EventEmitter {
    * This constructor is called after the general toolbar DOM has been created.
    *
    * @param container The container is the HTML element which contains the entire toolbar.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
+   * @param showShortcutIDs If true, menu buttons will show the shortcut IDs, instead of
+   *   the shortcuts.
    */
-  constructor(container: HTMLElement, showShortcuts: boolean) {
+  constructor(container: HTMLElement, showShortcutIDs: boolean) {
     super();
 
     // Store a reference to the container. We will attach menu buttons divs to it during
     // drag'n'drop operations.
     this.container = container;
 
-    // Store the showShortcuts argument.
-    this.showShortcuts = showShortcuts;
+    // Store the showShortcutIDs flag.
+    this.showShortcutIDs = showShortcutIDs;
 
     // Store a reference to the trash tab. This is the only drop target for dragged menus.
     this.trashTab = this.container.querySelector(
@@ -108,7 +105,7 @@ export class MenusTab extends EventEmitter {
       name: menu.nodes.name,
       active: index === currentMenu,
       description:
-        (this.showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
+        (this.showShortcutIDs ? menu.shortcutID : menu.shortcut) || 'Not bound.',
       icon: IconThemeRegistry.getInstance()
         .getTheme(menu.nodes.iconTheme)
         .createDiv(menu.nodes.icon).outerHTML,
@@ -157,7 +154,9 @@ export class MenusTab extends EventEmitter {
       `#menu-button-${index} .description`
     );
     if (description) {
-      description.textContent = menus[index].shortcut || 'Not bound.';
+      description.textContent =
+        (this.showShortcutIDs ? menus[index].shortcutID : menus[index].shortcut) ||
+        'Not bound.';
     }
   }
 }

--- a/src/renderer/editor/toolbar/toolbar.scss
+++ b/src/renderer/editor/toolbar/toolbar.scss
@@ -125,19 +125,6 @@
     }
   }
 
-  .swirl {
-    display: inline-block;
-    background-image: url(../../assets/images/swirl.svg);
-    width: 160px;
-    height: 14px;
-
-    &.vertical {
-      width: 14px;
-      height: 160px;
-      background-image: url(../../assets/images/swirl-vertical.svg);
-    }
-  }
-
   .toolbar-button-grid {
     display: grid;
     gap: 10px;

--- a/src/renderer/editor/toolbar/toolbar.ts
+++ b/src/renderer/editor/toolbar/toolbar.ts
@@ -104,18 +104,22 @@ export class Toolbar extends EventEmitter {
    *
    * @param menus A list of all menus.
    * @param currentMenu The index of the currently selected menu.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  public setMenus(menus: Array<IMenu>, currentMenu: number) {
-    this.menusTab.setMenus(menus, currentMenu);
+  public setMenus(menus: Array<IMenu>, currentMenu: number, showShortcuts: boolean) {
+    this.menusTab.setMenus(menus, currentMenu, showShortcuts);
   }
 
   /**
    * Whenever the content of the trash changes, the trash tab needs to be updated.
    *
    * @param items A list of all trashed menus and menu items.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  public setTrashedThings(items: Array<IMenu | IEditorMenuItem>) {
-    this.trashTab.setTrashedThings(items);
+  public setTrashedThings(items: Array<IMenu | IEditorMenuItem>, showShortcuts: boolean) {
+    this.trashTab.setTrashedThings(items, showShortcuts);
   }
 
   /**

--- a/src/renderer/editor/toolbar/toolbar.ts
+++ b/src/renderer/editor/toolbar/toolbar.ts
@@ -76,7 +76,7 @@ export class Toolbar extends EventEmitter {
     this.initTabs();
 
     // Initialize the menus tab and forward its events.
-    this.menusTab = new MenusTab(this.container, backend.supportsShortcuts);
+    this.menusTab = new MenusTab(this.container, !backend.supportsShortcuts);
     this.menusTab.on('add-menu', () => this.emit('add-menu'));
     this.menusTab.on('select-menu', (index) => this.emit('select-menu', index));
     this.menusTab.on('delete-menu', (index) => this.emit('delete-menu', index));
@@ -86,7 +86,7 @@ export class Toolbar extends EventEmitter {
     this.addItemsTab.on('add-item', (typeName) => this.emit('add-item', typeName));
 
     // Initialize the trash tab and forward its events.
-    this.trashTab = new TrashTab(this.container, backend.supportsShortcuts);
+    this.trashTab = new TrashTab(this.container, !backend.supportsShortcuts);
     this.trashTab.on('restore-menu', (index) => this.emit('restore-deleted-menu', index));
     this.trashTab.on('restore-item', (index) => this.emit('restore-deleted-item', index));
     this.trashTab.on('stash-item', (index) => this.emit('stash-deleted-item', index));

--- a/src/renderer/editor/toolbar/toolbar.ts
+++ b/src/renderer/editor/toolbar/toolbar.ts
@@ -10,7 +10,7 @@
 
 import Handlebars from 'handlebars';
 import { EventEmitter } from 'events';
-import { IMenu } from '../../../common';
+import { IMenu, IBackendInfo } from '../../../common';
 import { AddItemsTab } from './add-items-tab';
 import { MenusTab } from './menus-tab';
 import { TrashTab } from './trash-tab';
@@ -64,8 +64,11 @@ export class Toolbar extends EventEmitter {
   /**
    * This constructor creates the HTML elements for the toolbar and wires up all the
    * functionality.
+   *
+   * @param backend The backend info is used to determine if the backend supports
+   *   shortcuts.
    */
-  constructor() {
+  constructor(backend: IBackendInfo) {
     super();
 
     this.loadContent();
@@ -73,7 +76,7 @@ export class Toolbar extends EventEmitter {
     this.initTabs();
 
     // Initialize the menus tab and forward its events.
-    this.menusTab = new MenusTab(this.container);
+    this.menusTab = new MenusTab(this.container, backend.supportsShortcuts);
     this.menusTab.on('add-menu', () => this.emit('add-menu'));
     this.menusTab.on('select-menu', (index) => this.emit('select-menu', index));
     this.menusTab.on('delete-menu', (index) => this.emit('delete-menu', index));
@@ -83,7 +86,7 @@ export class Toolbar extends EventEmitter {
     this.addItemsTab.on('add-item', (typeName) => this.emit('add-item', typeName));
 
     // Initialize the trash tab and forward its events.
-    this.trashTab = new TrashTab(this.container);
+    this.trashTab = new TrashTab(this.container, backend.supportsShortcuts);
     this.trashTab.on('restore-menu', (index) => this.emit('restore-deleted-menu', index));
     this.trashTab.on('restore-item', (index) => this.emit('restore-deleted-item', index));
     this.trashTab.on('stash-item', (index) => this.emit('stash-deleted-item', index));
@@ -104,22 +107,18 @@ export class Toolbar extends EventEmitter {
    *
    * @param menus A list of all menus.
    * @param currentMenu The index of the currently selected menu.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
    */
-  public setMenus(menus: Array<IMenu>, currentMenu: number, showShortcuts: boolean) {
-    this.menusTab.setMenus(menus, currentMenu, showShortcuts);
+  public setMenus(menus: Array<IMenu>, currentMenu: number) {
+    this.menusTab.setMenus(menus, currentMenu);
   }
 
   /**
    * Whenever the content of the trash changes, the trash tab needs to be updated.
    *
    * @param items A list of all trashed menus and menu items.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
    */
-  public setTrashedThings(items: Array<IMenu | IEditorMenuItem>, showShortcuts: boolean) {
-    this.trashTab.setTrashedThings(items, showShortcuts);
+  public setTrashedThings(items: Array<IMenu | IEditorMenuItem>) {
+    this.trashTab.setTrashedThings(items);
   }
 
   /**

--- a/src/renderer/editor/toolbar/trash-tab.ts
+++ b/src/renderer/editor/toolbar/trash-tab.ts
@@ -35,11 +35,8 @@ export class TrashTab extends EventEmitter {
   /** The container is the HTML element which contains the entire toolbar. */
   private container: HTMLElement = null;
 
-  /**
-   * If true, menu buttons will show the shortcuts, else they will show the shortcut
-   * names.
-   */
-  private showShortcuts: boolean = false;
+  /** If true, menu buttons will show the shortcut IDs, instead of the shortcuts. */
+  private showShortcutIDs: boolean = false;
 
   /** This is the HTML element which contains the trash tab's content. */
   private tab: HTMLElement = null;
@@ -63,18 +60,18 @@ export class TrashTab extends EventEmitter {
    * This constructor is called after the general toolbar DOM has been created.
    *
    * @param container The container is the HTML element which contains the entire toolbar.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
+   * @param showShortcutIDs If true, menu buttons will show the shortcut IDs, instead of
+   *   the shortcuts.
    */
-  constructor(container: HTMLElement, showShortcuts: boolean) {
+  constructor(container: HTMLElement, showShortcutIDs: boolean) {
     super();
 
     // Store a reference to the container. We will attach menu buttons divs to it during
     // drag'n'drop operations.
     this.container = container;
 
-    // Store the showShortcuts argument.
-    this.showShortcuts = showShortcuts;
+    // Store the showShortcutIDs flag.
+    this.showShortcutIDs = showShortcutIDs;
 
     // Store a reference to the potential drop targets.
     this.stashTab = this.container.querySelector(
@@ -133,7 +130,7 @@ export class TrashTab extends EventEmitter {
           isMenu: true,
           name: menu.nodes.name,
           description:
-            (this.showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
+            (this.showShortcutIDs ? menu.shortcutID : menu.shortcut) || 'Not bound.',
           icon: IconThemeRegistry.getInstance()
             .getTheme(menu.nodes.iconTheme)
             .createDiv(menu.nodes.icon).outerHTML,

--- a/src/renderer/editor/toolbar/trash-tab.ts
+++ b/src/renderer/editor/toolbar/trash-tab.ts
@@ -35,6 +35,12 @@ export class TrashTab extends EventEmitter {
   /** The container is the HTML element which contains the entire toolbar. */
   private container: HTMLElement = null;
 
+  /**
+   * If true, menu buttons will show the shortcuts, else they will show the shortcut
+   * names.
+   */
+  private showShortcuts: boolean = false;
+
   /** This is the HTML element which contains the trash tab's content. */
   private tab: HTMLElement = null;
 
@@ -57,13 +63,18 @@ export class TrashTab extends EventEmitter {
    * This constructor is called after the general toolbar DOM has been created.
    *
    * @param container The container is the HTML element which contains the entire toolbar.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, showShortcuts: boolean) {
     super();
 
     // Store a reference to the container. We will attach menu buttons divs to it during
     // drag'n'drop operations.
     this.container = container;
+
+    // Store the showShortcuts argument.
+    this.showShortcuts = showShortcuts;
 
     // Store a reference to the potential drop targets.
     this.stashTab = this.container.querySelector(
@@ -96,7 +107,7 @@ export class TrashTab extends EventEmitter {
     this.tab = this.container.querySelector('#kando-trash-tab');
 
     // Initialize the trash tab with an empty list of trashed items.
-    this.setTrashedThings([], false);
+    this.setTrashedThings([]);
   }
 
   /**
@@ -104,13 +115,8 @@ export class TrashTab extends EventEmitter {
    * completely updates the trash tab's content.
    *
    * @param things The menus or menu items which are currently in the trash.
-   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
-   *   show the shortcut names.
    */
-  public setTrashedThings(
-    things: Array<IMenu | IEditorMenuItem>,
-    showShortcuts: boolean
-  ) {
+  public setTrashedThings(things: Array<IMenu | IEditorMenuItem>) {
     this.dragger.removeAllDraggables();
 
     const template = Handlebars.compile(
@@ -127,7 +133,7 @@ export class TrashTab extends EventEmitter {
           isMenu: true,
           name: menu.nodes.name,
           description:
-            (showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
+            (this.showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
           icon: IconThemeRegistry.getInstance()
             .getTheme(menu.nodes.iconTheme)
             .createDiv(menu.nodes.icon).outerHTML,

--- a/src/renderer/editor/toolbar/trash-tab.ts
+++ b/src/renderer/editor/toolbar/trash-tab.ts
@@ -96,7 +96,7 @@ export class TrashTab extends EventEmitter {
     this.tab = this.container.querySelector('#kando-trash-tab');
 
     // Initialize the trash tab with an empty list of trashed items.
-    this.setTrashedThings([]);
+    this.setTrashedThings([], false);
   }
 
   /**
@@ -104,8 +104,13 @@ export class TrashTab extends EventEmitter {
    * completely updates the trash tab's content.
    *
    * @param things The menus or menu items which are currently in the trash.
+   * @param showShortcuts If true, menu buttons will show the shortcuts, else they will
+   *   show the shortcut names.
    */
-  public setTrashedThings(things: Array<IMenu | IEditorMenuItem>) {
+  public setTrashedThings(
+    things: Array<IMenu | IEditorMenuItem>,
+    showShortcuts: boolean
+  ) {
     this.dragger.removeAllDraggables();
 
     const template = Handlebars.compile(
@@ -121,7 +126,8 @@ export class TrashTab extends EventEmitter {
         return {
           isMenu: true,
           name: menu.nodes.name,
-          description: menu.shortcut || 'Not bound.',
+          description:
+            (showShortcuts ? menu.shortcut : menu.shortcutName) || 'Not bound.',
           icon: IconThemeRegistry.getInstance()
             .getTheme(menu.nodes.iconTheme)
             .createDiv(menu.nodes.icon).outerHTML,

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -58,6 +58,11 @@ contextBridge.exposeInMainWorld('api', {
     },
   },
 
+  /** This will return some information about the currently used backend. */
+  getBackendInfo: function () {
+    return ipcRenderer.invoke('get-backend-info');
+  },
+
   /**
    * This will unbind all menu shortcuts. This is used when the menu editor is shown.
    * Otherwise, the shortcuts would interfere with the editor.


### PR DESCRIPTION
This adds the possibility to change the global shortcut ID on platforms which do not support direct binding of global shortcuts. For instance, on KDE/Wayland or on Hyprland, Kando can not directly bind global shortcuts. On those platforms, the menu editor shows a text field instead of the shortcut picker. Here you can enter a unique ID for the shortcut and then use the global shortcut settings of the desktop environment to bind the shortcut ID to a key combination.