### PR TITLE
Fix turbo mode for centered menus

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### Changed
 
 - On macOS, the application settings are now stored in `~/Library/Application Support/kando/` (with a lowercase `kando`). This is more consistent with the other platforms and macOS seems to handle this in a case-insensitive way, so the settings should be preserved when upgrading from an older version.
+- When a menu is opened in screen-center mode, turbo-mode is now disabled initially. This is to prevent accidental navigation when the menu is opened and a key is still pressed. Once all keyboard keys are released, turbo-mode can be activated by pressing and holding any key.
 - The description line of hotkey items in the stash or in the trash now shows the hotkey in a shorter format. For instance, "ControlLeft+AltLeft+ArrowRight" is now shown as "Ctrl + Alt + ArrowRight".
 
 #### Fixed

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -8,7 +8,14 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { IBackendInfo, IVec2, IMenuItem, IAppSettings, IMenuSettings } from '../common';
+import {
+  IBackendInfo,
+  IVec2,
+  IMenuItem,
+  IAppSettings,
+  IMenuSettings,
+  IShowMenuOptions,
+} from '../common';
 
 // Declare the API to the host process. See preload.ts for more information on the exposed
 // functions. The API has to be declared here again, because the TypeScript compiler
@@ -33,9 +40,7 @@ declare global {
       showDevTools: () => void;
       movePointer: (dist: IVec2) => void;
       log: (message: string) => void;
-      showMenu: (
-        func: (root: IMenuItem, menuPosition: IVec2, windowSize: IVec2) => void
-      ) => void;
+      showMenu: (func: (root: IMenuItem, options: IShowMenuOptions) => void) => void;
       showEditor: (func: () => void) => void;
       hoverItem: (path: string) => void;
       unhoverItem: (path: string) => void;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -132,6 +132,30 @@ export interface IMenu {
 }
 
 /**
+ * This interface is used to describe the additional information that is passed to the
+ * `showMenu` function when the main process requests the menu to be shown.
+ */
+export interface IShowMenuOptions {
+  /** The position of the mouse cursor when the menu was opened. */
+  menuPosition: IVec2;
+
+  /**
+   * The size of the window. Usually, this is the same as window.innerWidth and
+   * window.innerHeight. However, when the window was just resized, this can be different.
+   * Therefore, we need to pass it from the main process.
+   */
+  windowSize: IVec2;
+
+  /**
+   * If this is set, a key has to be pressed first before the turbo mode will be
+   * activated. Else, the turbo mode will be activated immediately when the menu is opened
+   * and a key is already pressed. This is useful for menus that are not opened at the
+   * mouse pointer.
+   */
+  deferredTurboMode: boolean;
+}
+
+/**
  * This interface describes the content of the menu settings file. It contains the
  * configured menus as well as the currently stashed menus.
  */

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -221,13 +221,15 @@ export class KandoApp {
           y: workarea.height,
         };
 
-        // Send the menu to the renderer process.
-        this.window.webContents.send(
-          'show-menu',
-          this.lastMenu.root,
+        // Send the menu to the renderer process. If the menu is centered, we delay the
+        // turbo mode. This way, a key has to be pressed first before the turbo mode is
+        // activated. Else, the turbo mode would be activated immediately when the menu is
+        // opened which is not nice if it is not opened at the pointer position.
+        this.window.webContents.send('show-menu', this.lastMenu.root, {
           menuPosition,
-          windowSize
-        );
+          windowSize,
+          deferredTurboMode: this.lastMenu.centered,
+        });
       })
       .catch((err) => {
         console.error('Failed to show menu: ' + err);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -25,8 +25,8 @@ window.api.getBackendInfo().then((info) => {
   const editor = new Editor(document.getElementById('kando-editor'), info);
 
   // Show the menu when the main process requests it.
-  window.api.showMenu((root, menuPosition, windowSize) => {
-    menu.show(root, menuPosition, windowSize);
+  window.api.showMenu((root, options) => {
+    menu.show(root, options);
     editor.show();
   });
 

--- a/src/renderer/menu/input-tracker.ts
+++ b/src/renderer/menu/input-tracker.ts
@@ -127,7 +127,6 @@ export class InputTracker extends EventEmitter {
    * is already pressed.
    */
   public set deferredTurboMode(val: boolean) {
-    window.api.log('set deferred turbo mode');
     this._deferredTurboMode = val;
     this.turboMode = false;
   }

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -11,7 +11,7 @@
 import { EventEmitter } from 'events';
 
 import * as math from '../math';
-import { IVec2 } from '../../common';
+import { IShowMenuOptions, IVec2 } from '../../common';
 import { IRenderedMenuItem } from './rendered-menu-item';
 import { CenterText } from './center-text';
 import { GestureDetection } from './gesture-detection';
@@ -173,8 +173,8 @@ export class Menu extends EventEmitter {
 
     // In order to keep track of any pressed key for the turbo mode, we listen to keydown
     // and keyup events.
-    document.addEventListener('keydown', (event) => {
-      this.input.onKeyDownEvent(event);
+    document.addEventListener('keydown', () => {
+      this.input.onKeyDownEvent();
     });
 
     // If the last modifier is released while a menu item is dragged around, we select it.
@@ -225,20 +225,19 @@ export class Menu extends EventEmitter {
   }
 
   /**
-   * This method is called when the menu is shown. Currently, it just creates a test menu.
+   * This method is called when the menu is shown. It will create the DOM tree for the
+   * given root item and all its children. It will also set up the angles and positions of
+   * all items and show the menu.
    *
-   * @param position The position of the mouse cursor when the menu was opened.
-   * @param windowSize The size of the window. Usually, this is the same as
-   *   window.innerWidth and window.innerHeight. However, when the window was just
-   *   resized, this can be different. Therefore, we need to pass it from the main
-   *   process.
+   * @param options Some additional information on how to show the menu.
    */
-  public show(root: IRenderedMenuItem, position: IVec2, windowSize: IVec2) {
+  public show(root: IRenderedMenuItem, options: IShowMenuOptions) {
     this.clear();
 
-    this.windowSize = windowSize;
+    this.windowSize = options.windowSize;
 
-    this.input.update(position);
+    this.input.deferredTurboMode = options.deferredTurboMode;
+    this.input.update(options.menuPosition);
     this.input.ignoreNextMotionEvents();
 
     this.root = root;

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -9,7 +9,13 @@
 // SPDX-License-Identifier: MIT
 
 import { ipcRenderer, contextBridge } from 'electron';
-import { IVec2, IMenuItem, IAppSettings, IMenuSettings } from '../common';
+import {
+  IVec2,
+  IMenuItem,
+  IAppSettings,
+  IMenuSettings,
+  IShowMenuOptions,
+} from '../common';
 
 /**
  * There is a well-defined API between the host process and the renderer process. The
@@ -83,12 +89,8 @@ contextBridge.exposeInMainWorld('api', {
    * @param callback This callback will be called with the root item of the menu and the
    *   position of the mouse cursor.
    */
-  showMenu: function (
-    callback: (root: IMenuItem, menuPosition: IVec2, windowSize: IVec2) => void
-  ) {
-    ipcRenderer.on('show-menu', (event, root, menuPosition, windowSize) =>
-      callback(root, menuPosition, windowSize)
-    );
+  showMenu: function (callback: (root: IMenuItem, options: IShowMenuOptions) => void) {
+    ipcRenderer.on('show-menu', (event, root, options) => callback(root, options));
   },
 
   /**


### PR DESCRIPTION
When a menu is opened in screen-center mode, turbo-mode is now disabled initially. This is to prevent accidental navigation when the menu is opened and a key is still pressed. Once all keyboard keys are released, turbo-mode can be activated by pressing and holding any key.

Related to #462.