### PR TITLE
Enforce naming convention

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,13 @@
 
 /* eslint-env node */
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-  root: true,
-  rules: {
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-var-requires': 'off',
+  extends : ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser : '@typescript-eslint/parser',
+  plugins : ['@typescript-eslint'],
+  root : true,
+  rules : {
+    '@typescript-eslint/no-empty-function' : 'off',
+    '@typescript-eslint/no-var-requires' : 'off',
+    '@typescript-eslint/naming-convention' : 'error',
   },
 };

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - On macOS, the application settings are now stored in `~/Library/Application Support/kando/` (with a lowercase `kando`). This is more consistent with the other platforms and macOS seems to handle this in a case-insensitive way, so the settings should be preserved when upgrading from an older version.
 - When a menu is opened in screen-center mode, turbo-mode is now disabled initially. This is to prevent accidental navigation when the menu is opened and a key is still pressed. Once all keyboard keys are released, turbo-mode can be activated by pressing and holding any key.
 - The description line of hotkey items in the stash or in the trash now shows the hotkey in a shorter format. For instance, "ControlLeft+AltLeft+ArrowRight" is now shown as "Ctrl + Alt + ArrowRight".
+- An [ESLint rule](https://typescript-eslint.io/rules/naming-convention/) which enforces naming conventions is used now. This should make the code more consistent, easier to read, and easier to contribute to.
 
 #### Fixed
 

--- a/src/common/key-codes.ts
+++ b/src/common/key-codes.ts
@@ -20,7 +20,7 @@ import { IKeySequence } from '.';
  */
 export function mapKeys(keys: IKeySequence, os: 'windows' | 'macos' | 'linux'): number[] {
   return keys.map((key) => {
-    const code = KeyCodes.get(key.name.toLowerCase())?.[os];
+    const code = KEY_CODES.get(key.name.toLowerCase())?.[os];
 
     if (!code) {
       throw new Error(`Unknown key: ${key.name}`);
@@ -38,7 +38,7 @@ export function mapKeys(keys: IKeySequence, os: 'windows' | 'macos' | 'linux'): 
  * @returns The fixed key code.
  */
 export function fixKeyCodeCase(code: string): string {
-  return ProperKeyCase.get(code.toLowerCase()) ?? code;
+  return PROPER_KEY_CASE.get(code.toLowerCase()) ?? code;
 }
 
 /**
@@ -48,7 +48,7 @@ export function fixKeyCodeCase(code: string): string {
  * @returns True if the key code is known.
  */
 export function isKnownKeyCode(code: string) {
-  return ProperKeyCase.has(code.toLowerCase());
+  return PROPER_KEY_CASE.has(code.toLowerCase());
 }
 
 /**
@@ -67,7 +67,7 @@ interface IKeyMapping {
  * insensitive. However, we usually want to display the key names in a user-friendly way.
  * This map is used to convert the key names to proper case.
  */
-const ProperKeyCase: Map<string, string> = new Map([
+const PROPER_KEY_CASE: Map<string, string> = new Map([
   ['again', 'Again'],
   ['altleft', 'AltLeft'],
   ['altright', 'AltRight'],
@@ -234,7 +234,7 @@ const ProperKeyCase: Map<string, string> = new Map([
 
 // The values in this map are derived from the tables on this page:
 // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
-const KeyCodes: Map<string, IKeyMapping> = new Map([
+const KEY_CODES: Map<string, IKeyMapping> = new Map([
   [
     'again',
     {

--- a/src/main/backends/index.ts
+++ b/src/main/backends/index.ts
@@ -35,26 +35,31 @@ export function getBackend(): Backend | null {
     console.log(`Running on Linux (${desktop} on ${session}).`);
 
     if ((desktop === 'GNOME' || desktop === 'Unity') && session === 'wayland') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { GnomeBackend } = require('./linux/gnome/wayland/backend');
       return new GnomeBackend();
     }
 
     if (desktop === 'KDE' && session === 'x11') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { KDEX11Backend } = require('./linux/kde/x11/backend');
       return new KDEX11Backend();
     }
 
     if (desktop === 'KDE' && session === 'wayland') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { KDEWaylandBackend } = require('./linux/kde/wayland/backend');
       return new KDEWaylandBackend();
     }
 
     if (desktop === 'Hyprland') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { HyprBackend } = require('./linux/hyprland/backend');
       return new HyprBackend();
     }
 
     if (session === 'x11') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { X11Backend } = require('./linux/x11/backend');
       return new X11Backend();
     }
@@ -65,12 +70,14 @@ export function getBackend(): Backend | null {
 
   if (os.platform() === 'win32') {
     console.log(`Running on Windows ${os.release()}.`);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { WindowsBackend } = require('./windows/backend');
     return new WindowsBackend();
   }
 
   if (os.platform() === 'darwin') {
     console.log(`Running on MacOS ${os.release()}.`);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { MacosBackend } = require('./macos/backend');
     return new MacosBackend();
   }

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -108,7 +108,7 @@ export class KDEWaylandBackend implements Backend {
     this.wmInfoScriptPath = this.storeScript(
       'get-info.js',
       `callDBus('org.kandomenu.kando', '/org/kandomenu/kando', 
-               'org.kandomenu.kando', 'SendWMInfo',
+               'org.kandomenu.kando', 'sendWMInfo',
                workspace.${property} ? workspace.${property}.caption : "",
                workspace.${property} ? workspace.${property}.resourceClass : "",
                workspace.cursorPos.x, workspace.cursorPos.y,
@@ -124,8 +124,8 @@ export class KDEWaylandBackend implements Backend {
     this.kandoInterface = new CustomInterface('org.kandomenu.kando');
     CustomInterface.configureMembers({
       methods: {
-        SendWMInfo: { inSignature: 'ssii', outSignature: '', noReply: false },
-        Trigger: { inSignature: 's', outSignature: '', noReply: false },
+        sendWMInfo: { inSignature: 'ssii', outSignature: '', noReply: false },
+        trigger: { inSignature: 's', outSignature: '', noReply: false },
       },
     });
 
@@ -269,7 +269,7 @@ export class KDEWaylandBackend implements Backend {
             () => {
               console.log('Kando: Triggered.');
               callDBus('org.kandomenu.kando', '/org/kandomenu/kando',
-                       'org.kandomenu.kando', 'Trigger', '${id}',
+                       'org.kandomenu.kando', 'trigger', '${id}',
                        () => console.log('Kando: Triggered.'));
             }
           )) {
@@ -382,7 +382,7 @@ class CustomInterface extends DBus.interface.Interface {
   public triggerCallback: (shortcutID: string) => void;
 
   // This is called by the get-info KWin script.
-  public SendWMInfo(
+  public sendWMInfo(
     windowName: string,
     appName: string,
     pointerX: number,
@@ -394,7 +394,7 @@ class CustomInterface extends DBus.interface.Interface {
   }
 
   // This is called by the global-shortcut KWin script whenever the trigger shortcut is pressed.
-  public Trigger(shortcutID: string) {
+  public trigger(shortcutID: string) {
     if (this.triggerCallback) {
       this.triggerCallback(shortcutID);
     }

--- a/src/main/backends/linux/portals/remote-desktop.ts
+++ b/src/main/backends/linux/portals/remote-desktop.ts
@@ -106,7 +106,9 @@ export class RemoteDesktop extends DesktopPortal {
   private async createSession() {
     return this.makeRequest((request) => {
       this.interface.CreateSession({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         session_handle_token: new DBus.Variant('s', this.session.token),
       });
     });
@@ -121,6 +123,7 @@ export class RemoteDesktop extends DesktopPortal {
   private async requestDevices() {
     return this.makeRequest((request) => {
       this.interface.SelectDevices(this.session.path, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
         types: new DBus.Variant('u', 1 | 2),
       });
@@ -136,6 +139,7 @@ export class RemoteDesktop extends DesktopPortal {
   private async start() {
     return this.makeRequest((request) => {
       this.interface.Start(this.session.path, '', {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
       });
     });

--- a/src/renderer/editor/common/dnd-manager.ts
+++ b/src/renderer/editor/common/dnd-manager.ts
@@ -15,6 +15,12 @@ import { IDraggable } from './draggable';
 import { IDropTarget } from './drop-target';
 
 /**
+ * This is the threshold in pixels which is used to differentiate between a click and a
+ * drag.
+ */
+const DRAG_THRESHOLD = 5;
+
+/**
  * This class is used to manage drag and drop operations in the editor. In Kando, there is
  * only one instance of this class which is created in the `Editor` class. It is used to
  * register drop targets and draggables. It will listen to pointer and touch events and
@@ -28,12 +34,6 @@ import { IDropTarget } from './drop-target';
  *   from drop targets.
  */
 export class DnDManager extends EventEmitter {
-  /**
-   * This is the threshold in pixels which is used to differentiate between a click and a
-   * drag.
-   */
-  private readonly DRAG_THRESHOLD = 5;
-
   /** This set contains all registered drop targets. */
   private dropTargets: Set<IDropTarget> = new Set();
 
@@ -95,7 +95,7 @@ export class DnDManager extends EventEmitter {
         const viewportCoords = this.getCoords(e2);
         const offset = math.subtract(viewportCoords, dragStart);
 
-        if (math.getLength(offset) > this.DRAG_THRESHOLD) {
+        if (math.getLength(offset) > DRAG_THRESHOLD) {
           // If we are not already dragging something, we start a new drag operation.
           if (this.currentlyDragged === null) {
             this.currentlyDragged = draggable;


### PR DESCRIPTION
This adds an [ESLint rule](https://typescript-eslint.io/rules/naming-convention/) which enforces naming conventions. This should make the code more consistent, easier to read, and easier to contribute to.