### PR TITLE
Drag-copy items

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - The "Execute Delayed" property of hotkey and macro items is now called "Execute After Closing the Menu". This should make it clearer what this property does.
 - The "Execute After Closing the Menu" property is now enabled by default for hotkey and macro items. This should make it easier to use these items in a way that is expected by most users.
 - Command items now have an "Execute After Closing the Menu" property as well. This allows to execute a command after closing the menu. This is useful if the command should be executed in the context of the currently focused window.
+- The menu items in the editor's preview use now a pointer cursor when hovered. This should make it clearer that the items are interactive.
 
 ## [Kando 1.1.0](https://github.com/kando-menu/kando/releases/tag/v1.1.0)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,10 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 **Release Date:** TBD
 
+#### Added
+
+- If <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved.
+
 #### Changed
 
 - The "Execute Delayed" property of hotkey and macro items is now called "Execute After Closing the Menu". This should make it clearer what this property does.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### Added
 
-- If <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved.
+- If <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved. Due to an [issue in electron](https://github.com/electron/electron/issues/8730), the cursor graphic does not change when dragging or copying items on macOS. The operation is still performed correctly, though.
 
 #### Changed
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -130,6 +130,26 @@ export interface IMenuItem {
 }
 
 /**
+ * This function creates a deep copy of an IMenuItem. It can also be used to strip all
+ * properties from an menu item object which are not present in an IMenuItem. This is for
+ * instance used before saving the menu settings.
+ *
+ * @param item The menu item to copy.
+ * @returns The copied menu item.
+ */
+export function deepCopyMenuItem(item: IMenuItem): IMenuItem {
+  return {
+    type: item.type,
+    data: item.data,
+    name: item.name,
+    icon: item.icon,
+    iconTheme: item.iconTheme,
+    children: item.children?.map(deepCopyMenuItem),
+    angle: item.angle,
+  };
+}
+
+/**
  * This interface describes a menu. It contains the root item of the menu, the shortcut to
  * open the menu and a flag indicating whether the menu should be opened in the center of
  * the screen or at the mouse pointer.
@@ -165,6 +185,22 @@ export interface IMenu {
    * met them all is selected.
    */
   conditions?: IMenuConditions;
+}
+
+/**
+ * This function creates a deep copy of an IMenu.
+ *
+ * @param menu The menu to copy.
+ * @returns The copied menu.
+ */
+export function deepCopyMenu(menu: IMenu): IMenu {
+  return {
+    root: deepCopyMenuItem(menu.root),
+    shortcut: menu.shortcut,
+    shortcutID: menu.shortcutID,
+    centered: menu.centered,
+    conditions: structuredClone(menu.conditions),
+  };
 }
 
 /**

--- a/src/renderer/editor/common/dnd-manager.ts
+++ b/src/renderer/editor/common/dnd-manager.ts
@@ -140,15 +140,15 @@ export class DnDManager extends EventEmitter {
       };
 
       // This method is called when the pointer is released or the touch is canceled.
-      const onMouseUp = () => {
+      const onMouseUp = (e2: MouseEvent | TouchEvent) => {
         draggable.onMouseUp();
 
         // If we are currently dragging something over a drop target, we notify both the
         // draggable and the drop target about the drop operation.
         if (this.currentlyDragged) {
           if (this.currentDropTarget) {
-            draggable.onDrop(this.currentDropTarget);
-            this.currentDropTarget.onDrop(draggable);
+            draggable.onDrop(this.currentDropTarget, e2.ctrlKey);
+            this.currentDropTarget.onDrop(draggable, e2.ctrlKey);
           } else {
             draggable.onDragCancel();
           }

--- a/src/renderer/editor/common/dnd-manager.ts
+++ b/src/renderer/editor/common/dnd-manager.ts
@@ -183,7 +183,7 @@ export class DnDManager extends EventEmitter {
 
           clearListeners();
           e2.stopPropagation();
-        } else if (e2.key === 'Control') {
+        } else if (e2.key === 'Control' || e2.key === 'Meta') {
           document.body.style.cursor = 'copy';
         }
       };
@@ -191,7 +191,7 @@ export class DnDManager extends EventEmitter {
       // This method is called when a key is released. It changes the cursor back to the
       // move cursor.
       const onKeyUp = (e2: KeyboardEvent) => {
-        if (e2.key === 'Control') {
+        if (e2.key === 'Control' || e2.key === 'Meta') {
           document.body.style.cursor = 'grabbing';
         }
       };

--- a/src/renderer/editor/common/dnd-manager.ts
+++ b/src/renderer/editor/common/dnd-manager.ts
@@ -99,9 +99,14 @@ export class DnDManager extends EventEmitter {
           // If we are not already dragging something, we start a new drag operation.
           if (this.currentlyDragged === null) {
             this.currentlyDragged = draggable;
-            document.body.style.cursor = 'grabbing';
             draggable.onDragStart();
             this.emit('drag-start', draggable);
+          }
+
+          // Update the pointer graphic. If the Ctrl key is pressed, we show a copy
+          // cursor, otherwise we show a move cursor.
+          if (this.currentlyDragged) {
+            document.body.style.cursor = e2.ctrlKey ? 'copy' : 'grabbing';
           }
 
           // Notify the draggable about the current position.
@@ -159,9 +164,9 @@ export class DnDManager extends EventEmitter {
         clearListeners();
       };
 
-      // This method is called when the escape key is pressed. It cancels the drag
-      // operation.
-      const onEsc = (e2: KeyboardEvent) => {
+      // This method is called when a key is pressed. It cancels the drag
+      // operation on Escape and changes the cursor to the copy-cursor on Ctrl.
+      const onKeyDown = (e2: KeyboardEvent) => {
         if (e2.key === 'Escape') {
           if (this.currentlyDragged) {
             document.body.style.cursor = '';
@@ -178,6 +183,16 @@ export class DnDManager extends EventEmitter {
 
           clearListeners();
           e2.stopPropagation();
+        } else if (e2.key === 'Control') {
+          document.body.style.cursor = 'copy';
+        }
+      };
+
+      // This method is called when a key is released. It changes the cursor back to the
+      // move cursor.
+      const onKeyUp = (e2: KeyboardEvent) => {
+        if (e2.key === 'Control') {
+          document.body.style.cursor = 'grabbing';
         }
       };
 
@@ -187,7 +202,8 @@ export class DnDManager extends EventEmitter {
         window.removeEventListener('mouseup', onMouseUp);
         window.removeEventListener('touchend', onMouseUp);
         window.removeEventListener('touchcancel', onMouseUp);
-        window.removeEventListener('keydown', onEsc, true);
+        window.removeEventListener('keydown', onKeyDown, true);
+        window.removeEventListener('keyup', onKeyUp, true);
       };
 
       window.addEventListener('mousemove', onMotionEvent);
@@ -195,7 +211,8 @@ export class DnDManager extends EventEmitter {
       window.addEventListener('mouseup', onMouseUp);
       window.addEventListener('touchend', onMouseUp);
       window.addEventListener('touchcancel', onMouseUp);
-      window.addEventListener('keydown', onEsc, true);
+      window.addEventListener('keydown', onKeyDown, true);
+      window.addEventListener('keyup', onKeyUp, true);
     };
 
     // We need to store the abort controller to be able to remove the event listeners

--- a/src/renderer/editor/common/dnd-manager.ts
+++ b/src/renderer/editor/common/dnd-manager.ts
@@ -106,7 +106,7 @@ export class DnDManager extends EventEmitter {
           // Update the pointer graphic. If the Ctrl key is pressed, we show a copy
           // cursor, otherwise we show a move cursor.
           if (this.currentlyDragged) {
-            document.body.style.cursor = e2.ctrlKey ? 'copy' : 'grabbing';
+            document.body.style.cursor = e2.ctrlKey || e2.metaKey ? 'copy' : 'grabbing';
           }
 
           // Notify the draggable about the current position.
@@ -147,8 +147,8 @@ export class DnDManager extends EventEmitter {
         // draggable and the drop target about the drop operation.
         if (this.currentlyDragged) {
           if (this.currentDropTarget) {
-            draggable.onDrop(this.currentDropTarget, e2.ctrlKey);
-            this.currentDropTarget.onDrop(draggable, e2.ctrlKey);
+            draggable.onDrop(this.currentDropTarget, e2.ctrlKey || e2.metaKey);
+            this.currentDropTarget.onDrop(draggable, e2.ctrlKey || e2.metaKey);
           } else {
             draggable.onDragCancel();
           }

--- a/src/renderer/editor/common/draggable.ts
+++ b/src/renderer/editor/common/draggable.ts
@@ -72,8 +72,10 @@ export interface IDraggable {
    * corresponding `onDrop` method of the drop target.
    *
    * @param target The drop target on which the draggable element was dropped.
+   * @param shouldCopy If `true`, the draggable element is usppoed to be copied. If
+   *   `false`, it is supposed to be moved.
    */
-  onDrop(target: IDropTarget): void;
+  onDrop(target: IDropTarget, shouldCopy: boolean): void;
 
   /**
    * This method is called when the drag operation is canceled. You can use it to update

--- a/src/renderer/editor/common/drop-target.ts
+++ b/src/renderer/editor/common/drop-target.ts
@@ -62,6 +62,7 @@ export interface IDropTarget {
    * corresponding `onDrop` method of the draggable is called before this method.
    *
    * @param draggable The draggable which was dropped onto the target.
+   * @param shouldCopy If `true`, the draggable should be copied instead of moved.
    */
-  onDrop(draggable: IDraggable): void;
+  onDrop(draggable: IDraggable, shouldCopy: boolean): void;
 }

--- a/src/renderer/editor/common/editor-menu-item.ts
+++ b/src/renderer/editor/common/editor-menu-item.ts
@@ -29,22 +29,3 @@ export interface IEditorMenuItem extends IMenuItem {
    */
   computedAngle?: number;
 }
-
-/**
- * This function can be used to strip all properties from an IEditorMenuItem which are not
- * present in an IMenuItem. This is used before saving the menu settings.
- *
- * @param item The menu item to convert.
- * @returns The converted menu item.
- */
-export function toIMenuItem(item: IEditorMenuItem): IMenuItem {
-  return {
-    type: item.type,
-    data: item.data,
-    name: item.name,
-    icon: item.icon,
-    iconTheme: item.iconTheme,
-    children: item.children?.map(toIMenuItem),
-    angle: item.angle,
-  };
-}

--- a/src/renderer/editor/editor.ts
+++ b/src/renderer/editor/editor.ts
@@ -16,8 +16,12 @@ import { Toolbar } from './toolbar/toolbar';
 import { Background } from './background/background';
 import { Preview } from './preview/preview';
 import { Properties } from './properties/properties';
-import { IBackendInfo, IMenuSettings, IShowEditorOptions } from '../../common';
-import { toIMenuItem } from './common/editor-menu-item';
+import {
+  IBackendInfo,
+  IMenuSettings,
+  IShowEditorOptions,
+  deepCopyMenuItem,
+} from '../../common';
 import { DnDManager } from './common/dnd-manager';
 
 /**
@@ -245,11 +249,11 @@ export class Editor extends EventEmitter {
       // be saved to disc nor can they be cloned using the structured clone algorithm
       // which is used by Electron for IPC.
       this.menuSettings.menus.forEach((menu) => {
-        menu.root = toIMenuItem(menu.root);
+        menu.root = deepCopyMenuItem(menu.root);
       });
 
       // Also the stash needs to be converted back to IMenuItem objects.
-      this.menuSettings.stash = this.menuSettings.stash.map(toIMenuItem);
+      this.menuSettings.stash = this.menuSettings.stash.map(deepCopyMenuItem);
 
       window.api.menuSettings.set(this.menuSettings);
       this.menuSettings = null;

--- a/src/renderer/editor/preview/preview-draggable.ts
+++ b/src/renderer/editor/preview/preview-draggable.ts
@@ -100,14 +100,15 @@ export class PreviewDraggable extends EventEmitter implements IDraggable {
     }
   }
 
-  /** This is called when a drag operation is done. We emit the 'drop' event. */
-  public onDrop(target: IDropTarget) {
+  /** This is called when a drag operation is done. */
+  public onDrop(target: IDropTarget, shouldCopy: boolean) {
     if (this.item.angle === undefined) {
       // Reset the position of the dragged div.
       this.item.div.style.left = '';
       this.item.div.style.top = '';
       this.item.div.classList.remove('dragging');
-      this.emit('drop', target);
+
+      this.emit('drop', target, shouldCopy);
     }
   }
 

--- a/src/renderer/editor/preview/preview-drop-target.ts
+++ b/src/renderer/editor/preview/preview-drop-target.ts
@@ -14,7 +14,7 @@ import * as utils from './utils';
 import * as math from '../../math';
 import { IDropTarget } from '../common/drop-target';
 import { IVec2 } from '../../../common';
-import { IEditorMenuItem } from '../common/editor-menu-item';
+import { IEditorMenuItem, toIMenuItem } from '../common/editor-menu-item';
 import { IDraggable } from '../common/draggable';
 
 /**
@@ -189,11 +189,15 @@ export class PreviewDropTarget extends EventEmitter implements IDropTarget {
   }
 
   /** @inheritdoc */
-  public onDrop(draggable: IDraggable) {
-    // Items with fixed angles are not really dragged around. Only items without fixed
-    // angles can be dropped.
+  public onDrop(draggable: IDraggable, shouldCopy: boolean) {
+    // If the item is to be copied, we create a new item with the same data.
     const item = draggable.getData() as IEditorMenuItem;
-    this.emit('drop', item, this.dropInto, this.dropIndex);
+
+    if (shouldCopy) {
+      this.emit('drop', toIMenuItem(item), this.dropInto, this.dropIndex);
+    } else {
+      this.emit('drop', item, this.dropInto, this.dropIndex);
+    }
 
     this.dropIndex = null;
     this.dropInto = null;

--- a/src/renderer/editor/preview/preview-drop-target.ts
+++ b/src/renderer/editor/preview/preview-drop-target.ts
@@ -13,8 +13,8 @@ import { EventEmitter } from 'events';
 import * as utils from './utils';
 import * as math from '../../math';
 import { IDropTarget } from '../common/drop-target';
-import { IVec2 } from '../../../common';
-import { IEditorMenuItem, toIMenuItem } from '../common/editor-menu-item';
+import { IVec2, deepCopyMenuItem } from '../../../common';
+import { IEditorMenuItem } from '../common/editor-menu-item';
 import { IDraggable } from '../common/draggable';
 
 /**
@@ -194,7 +194,7 @@ export class PreviewDropTarget extends EventEmitter implements IDropTarget {
     const item = draggable.getData() as IEditorMenuItem;
 
     if (shouldCopy) {
-      this.emit('drop', toIMenuItem(item), this.dropInto, this.dropIndex);
+      this.emit('drop', deepCopyMenuItem(item), this.dropInto, this.dropIndex);
     } else {
       this.emit('drop', item, this.dropInto, this.dropIndex);
     }

--- a/src/renderer/editor/preview/preview.ts
+++ b/src/renderer/editor/preview/preview.ts
@@ -481,11 +481,16 @@ export class Preview extends EventEmitter {
       this.selectItem(item);
     });
 
-    // If the item is dropped somewhere outside the preview, we have to remove it from the
+    // If the item is moved to somewhere outside the preview, we have to remove it from the
     // children list of the current center item.
-    draggable.on('drop', (target) => {
+    draggable.on('drop', (target, shouldCopy) => {
       if (target !== this.dropTarget) {
-        this.removeItem(item);
+        if (shouldCopy) {
+          this.recomputeItemAngles();
+          this.updateAllPositions();
+        } else {
+          this.removeItem(item);
+        }
       }
     });
 
@@ -568,6 +573,7 @@ export class Preview extends EventEmitter {
    * visible menu items, including the back link div.
    */
   private updateAllPositions() {
+    window.api.log('updateAllPositions');
     const centerItem = this.getCenterItem();
     if (centerItem.children?.length > 0) {
       centerItem.children.forEach((child) => {

--- a/src/renderer/editor/preview/preview.ts
+++ b/src/renderer/editor/preview/preview.ts
@@ -573,7 +573,6 @@ export class Preview extends EventEmitter {
    * visible menu items, including the back link div.
    */
   private updateAllPositions() {
-    window.api.log('updateAllPositions');
     const centerItem = this.getCenterItem();
     if (centerItem.children?.length > 0) {
       centerItem.children.forEach((child) => {

--- a/src/renderer/editor/preview/style/index.scss
+++ b/src/renderer/editor/preview/style/index.scss
@@ -90,6 +90,7 @@
     border: 2px solid rgb(255, 255, 255);
     transition: all 150ms ease;
     touch-action: none;
+    cursor: pointer;
 
     display: flex;
     align-items: center;
@@ -107,6 +108,7 @@
       transition: none;
       z-index: 99;
       backdrop-filter: blur(5px);
+      cursor: inherit;
 
       .kando-menu-preview-label-container {
         opacity: 0;

--- a/src/renderer/editor/preview/style/index.scss
+++ b/src/renderer/editor/preview/style/index.scss
@@ -105,7 +105,6 @@
 
     &.dragging {
       transition: none;
-      pointer-events: none;
       z-index: 99;
       backdrop-filter: blur(5px);
 

--- a/src/renderer/editor/toolbar/drop-target-tab.ts
+++ b/src/renderer/editor/toolbar/drop-target-tab.ts
@@ -61,7 +61,6 @@ export class DropTargetTab extends EventEmitter implements IDropTarget {
 
   /** @inheritdoc */
   accepts(draggable: IDraggable, coords: IVec2) {
-    // We only accept only menus.
     if (!this.acceptedTypes.includes(draggable.getDataType())) {
       return false;
     }

--- a/src/renderer/editor/toolbar/stash-tab.ts
+++ b/src/renderer/editor/toolbar/stash-tab.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DropTargetTab } from './drop-target-tab';
-import { IMenuItem, IMenuSettings } from '../../../common';
+import { IMenuItem, IMenuSettings, deepCopyMenuItem } from '../../../common';
 import { ItemTypeRegistry } from '../../../common/item-type-registry';
 import { IconThemeRegistry } from '../../../common/icon-theme-registry';
 import { IDraggable } from '../common/draggable';
@@ -63,8 +63,8 @@ export class StashTab extends DropTargetTab {
   override onDrop(draggable: IDraggable) {
     super.onDrop(draggable);
 
-    // Add the dropped thing to the trash.
-    this.menuSettings.stash.push(draggable.getData() as IMenuItem);
+    // Add the dropped thing to the trash. We drop a copy of the item to the stash.
+    this.menuSettings.stash.push(deepCopyMenuItem(draggable.getData() as IMenuItem));
     this.redraw();
   }
 
@@ -114,9 +114,11 @@ export class StashTab extends DropTargetTab {
       this.dndManager.registerDraggable(draggable);
 
       // Remove the dropped item from the stash.
-      draggable.on('drop', () => {
-        this.menuSettings.stash = this.menuSettings.stash.filter((i) => i !== item);
-        this.redraw();
+      draggable.on('drop', (target, shouldCopy) => {
+        if (!shouldCopy) {
+          this.menuSettings.stash = this.menuSettings.stash.filter((i) => i !== item);
+          this.redraw();
+        }
       });
 
       this.draggables.push(draggable);

--- a/src/renderer/editor/toolbar/style/index.scss
+++ b/src/renderer/editor/toolbar/style/index.scss
@@ -180,6 +180,7 @@
   }
 
   &.dragging {
+    cursor: inherit;
     backdrop-filter: blur(5px);
     background-color: var(--bs-btn-active-bg);
     transition: none;

--- a/src/renderer/editor/toolbar/style/index.scss
+++ b/src/renderer/editor/toolbar/style/index.scss
@@ -183,7 +183,6 @@
     backdrop-filter: blur(5px);
     background-color: var(--bs-btn-active-bg);
     transition: none;
-    pointer-events: none;
     z-index: 1;
     position: absolute;
     top: 0;

--- a/src/renderer/editor/toolbar/toolbar-draggable.ts
+++ b/src/renderer/editor/toolbar/toolbar-draggable.ts
@@ -122,9 +122,9 @@ export class ToolbarDraggable<T> extends EventEmitter implements IDraggable {
   }
 
   /** @inheritdoc */
-  public onDrop(target: IDropTarget) {
+  public onDrop(target: IDropTarget, shouldCopy: boolean) {
     this.dragEnd(false);
-    this.emit('drop', target);
+    this.emit('drop', target, shouldCopy);
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
Fro now on, if <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved.