### PR TITLE
HiDPI Zoom

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### Added
 
 - **Copy Items:** If <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved. Due to an [issue in electron](https://github.com/electron/electron/issues/8730), the cursor graphic does not change when dragging or copying items on macOS. The operation is still performed correctly, though.
+- **Menu Scaling:** The menu now behaves properly when scaled via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>+</kbd>, <kbd>Ctrl</kbd>+<kbd>-</kbd>, and <kbd>Ctrl</kbd>+<kbd>0</kbd>. The scale factor is saved to and loaded from `config.json`. It's still a somewhat hidden feature, but once we have a general settings UI, this can be exposed via slider in the UI.
 
 #### Changed
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -49,11 +49,12 @@ Depending on your platform, the configuration files are located in different dir
 ### The General Configuration: `config.json`
 
 This file contains the general configuration of Kando.
-For now, only a single option is available:
+For now, only contains a few options.
 
 Property | Default Value | Description
 -------- | ------------- | -----------
 `sidebarVisible` | `true` | Whether the left sidebar is currently visible.
+`zoomFactor` | `1.0` | The zoom factor of the menu. This can be used to scale the menu on high-resolution screens.
 
 ### The Menu Configuration: `menus.json`
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -275,4 +275,7 @@ export interface IAppSettings {
 
   /** Whether the sidebar should be shown in the editor. */
   sidebarVisible: boolean;
+
+  /** A scale factor for the menu. */
+  zoomFactor: number;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,11 @@ app
   .whenReady()
   .then(() => kando.init())
   .then(() => {
+    // Save some settings when the app is closed.
+    app.on('before-quit', () => {
+      kando.saveSettings();
+    });
+
     // Show a nifty message when the app is about to quit.
     app.on('will-quit', async () => {
       await kando.quit();

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -77,6 +77,7 @@ export class KandoApp {
       menuTheme: 'none',
       editorTheme: 'none',
       sidebarVisible: true,
+      zoomFactor: 1,
     },
   });
 
@@ -124,6 +125,11 @@ export class KandoApp {
       this.updateTrayMenu();
     });
 
+    // When the app settings change, we need to apply the zoom factor to the window.
+    this.appSettings.onChange('zoomFactor', (newValue) => {
+      this.window.webContents.setZoomFactor(newValue);
+    });
+
     // Initialize the IPC communication to the renderer process.
     this.initRendererIPC();
 
@@ -136,6 +142,22 @@ export class KandoApp {
     // Add a tray icon to the system tray. This icon can be used to open the pie menu
     // and to quit the application.
     this.updateTrayMenu();
+  }
+
+  /**
+   * This is called when the app is about to close. It will save some settings before
+   * quitting.
+   */
+  public saveSettings() {
+    // Save the current zoom factor to the settings.
+    if (this.window) {
+      this.appSettings.set(
+        {
+          zoomFactor: this.window.webContents.getZoomFactor(),
+        },
+        false
+      );
+    }
   }
 
   /** This is called when the app is closed. It will unbind all shortcuts. */
@@ -434,6 +456,9 @@ export class KandoApp {
     });
 
     await this.window.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+
+    // Apply the stored zoom factor to the window.
+    this.window.webContents.setZoomFactor(this.appSettings.get('zoomFactor'));
   }
 
   /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -329,6 +329,10 @@ export class KandoApp {
           y: this.lastMenu.centered ? workarea.height / 2 : info.pointerY - workarea.y,
         };
 
+        // Account for the window's zoom factor.
+        menuPosition.x /= this.window.webContents.getZoomFactor();
+        menuPosition.y /= this.window.webContents.getZoomFactor();
+
         // We have to pass the size of the window to the renderer because window.innerWidth
         // and window.innerHeight are not reliable when the window has just been resized.
         const windowSize = {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -205,13 +205,17 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
    * once, you should avoid calling this method multiple times.
    *
    * @param newSettings The new settings object.
+   * @param emitEvents Whether events should be emitted for the changed properties.
    */
-  public set(newSettings: Partial<T>) {
+  public set(newSettings: Partial<T>, emitEvents = true) {
     if (this.watcher) {
       const oldSettings = { ...this.settings };
       this.settings = { ...this.settings, ...newSettings };
       this.saveSettings(this.settings);
-      this.emitEvents(this.settings, oldSettings);
+
+      if (emitEvents) {
+        this.emitEvents(this.settings, oldSettings);
+      }
     }
   }
 


### PR DESCRIPTION
The menu now behaves properly when scaled via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>+</kbd>, <kbd>Ctrl</kbd>+<kbd>-</kbd>, and <kbd>Ctrl</kbd>+<kbd>0</kbd>. The scale factor is saved to and loaded from `config.json`. It's still a somewhat hidden feature, but once we have a general settings UI, this can be exposed via slider in the UI.

This resolves #490.