### PR TITLE
Custom icon themes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,9 @@
 name: Checks
 
 on:
+  pull_request:
+    branches:
+      - '**'
   push:
     branches:
       - '**'

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ If you want to improve this documentation, please [open a pull request](https://
 * [Installation](installing.md)
 * [Usage](usage.md)
 * [Configuration](configuring.md)
-* [The Configuration Files](config-files.md)
+* [Config Files](config-files.md)
 
 
 <p align="center"><img src ="img/hr.svg" /></p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ If you want to improve this documentation, please [open a pull request](https://
 * [Installation](installing.md)
 * [Usage](usage.md)
 * [Configuration](configuring.md)
+
+## Advanced Topics
+
 * [Config Files](config-files.md)
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,5 +23,7 @@ If you want to improve this documentation, please [open a pull request](https://
 * [Installation](installing.md)
 * [Usage](usage.md)
 * [Configuration](configuring.md)
+* [The Configuration Files](config-files.md)
+
 
 <p align="center"><img src ="img/hr.svg" /></p>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### Added
 
+- **Custom Icon Themes:** You can now use your own icons in Kando! Read the [corresponding documentation](configuring.md#adding-custom-icon-themes) to learn how it is done.
 - **Copy Items:** If <kbd>Ctrl</kbd> or <kbd>Command</kbd> is pressed while dragging a menu or menu item in the editor, the item will be duplicated instead of moved. Due to an [issue in electron](https://github.com/electron/electron/issues/8730), the cursor graphic does not change when dragging or copying items on macOS. The operation is still performed correctly, though.
 - **Menu Scaling:** The menu now behaves properly when scaled via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>+</kbd>, <kbd>Ctrl</kbd>+<kbd>-</kbd>, and <kbd>Ctrl</kbd>+<kbd>0</kbd>. The scale factor is saved to and loaded from `config.json`. It's still a somewhat hidden feature, but once we have a general settings UI, this can be exposed via slider in the UI.
 - **Anchored Mode:** In addition to the existing "Centered Mode", there is now an "Anchored Mode". In this mode, submenus are opened at the position of the parent item. With this, the menu will always stay at the same position on the screen. With this mode, gesture selections are not possible, but it seems that some users prefer this behavior.
@@ -38,7 +39,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - "Open at Pointer" has been renamed to "Centered Mode" (and the condition has been inverted).
 - The menu items in the editor's preview use now a pointer cursor when hovered. This should make it clearer that the items are interactive.
 - Newly added items in the editor's preview are now selected by default.
-- The minimum distance your pointer has to travel to trigger a selection in mark mode has been reduced from 200 to 150 pixels. This makes it possible to draw gestures at a smaller scale.
+- The minimum distance your pointer has to travel to trigger a selection in marking mode has been reduced from 200 to 150 pixels. This makes it possible to draw gestures at a smaller scale.
 
 #### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - The menu items in the editor's preview use now a pointer cursor when hovered. This should make it clearer that the items are interactive.
 - Newly added items in the editor's preview are now selected by default.
 - The minimum distance your pointer has to travel to trigger a selection in marking mode has been reduced from 200 to 150 pixels. This makes it possible to draw gestures at a smaller scale.
+- When the user clicks on an external link in the editor, Kando's window will now fade out properly and the settings will be saved before the external link is opened.
 
 #### Fixed
 

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 <img src="img/banner08.jpg"></img>
 
-# The Configuration Files
+# The Config Files
 
 All settings are stored in **two configuration files** JSON files which you can also edit manually.
 `config.json` stores the general configuration of the application and `menus.json` stores the configuration of the individual menus.

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -1,0 +1,230 @@
+<!--
+SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+<img src="img/banner08.jpg"></img>
+
+# The Configuration Files
+
+All settings are stored in **two configuration files** JSON files which you can also edit manually.
+`config.json` stores the general configuration of the application and `menus.json` stores the configuration of the individual menus.
+Depending on your platform, the configuration files are located in different directories:
+
+* <img height="14" width="26" src="https://cdn.simpleicons.org/windows" /> Windows: `%appdata%\kando\`
+* <img height="14" width="26" src="https://cdn.simpleicons.org/apple" /> macOS: `~/Library/Application Support/kando/`
+* <img height="14" width="26" src="https://cdn.simpleicons.org/linux/black" /> Linux: `~/.config/kando/`
+
+**📝 JSON Format**: Both configuration files are JSON files. You can edit them with any text editor.
+
+**🔥 Hot Reloading:** Whenever you save a file, Kando will automatically reload the configuration.
+
+**✅ Validation:** Kando will validate the configuration files and [print errors to the console](installing.md#running-kando-from-the-command-line) if it finds any. In this case, the configuration will not be reloaded. If a configuration file is invalid at startup, Kando will use the default configuration instead.
+
+
+## The General Configuration: `config.json`
+
+This file contains the general configuration of Kando.
+
+Property | Default Value | Description
+-------- | ------------- | -----------
+`sidebarVisible` | `true` | Whether the left sidebar is currently visible.
+`zoomFactor` | `1.0` | The zoom factor of the menu. This can be used to scale the menu on high-resolution screens.
+`enableVersionCheck` | `true` | If set to `true`, Kando will check for new version regularly, and show a notification if a new version is available.
+
+## The Menu Configuration: `menus.json`
+
+This file contains the configuration of the individual menus.
+There are two top-level JSON objects: `menus` contains a list of _Menu Descriptions_ and `templates` contains a list of _Menu Descriptions_ or _Menu Item Descriptions_.
+
+```js
+{
+  "menus": [
+    {
+      // First Menu Description.
+      // ...
+    },
+    {
+      // Second Menu Description.
+      // ...
+    },
+    // ...
+  ],
+  "templates": [
+    // Can contain Menu Descriptions and Menu Item Descriptions.
+  ]
+}
+```
+
+> [!TIP]
+> You can have a look at a the example menu configurations [here](https://github.com/kando-menu/kando/tree/main/src/main/example-menus)!
+
+
+### Menu Descriptions
+
+The items in the `menus` list are called menu descriptions.
+They are JSON objects with the following properties:
+
+Property | Default Value | Description
+-------- | ------------- | -----------
+`shortcut` | `""` | The shortcut which opens the menu. This is a string which can contain multiple keys separated by `+`. For example, `"Ctrl+Shift+K"` or `"Cmd+Shift+K"`. If empty, the menu will not have a shortcut. See [Menu Shortcuts vs. Simulated Hotkeys](configuring.md#menu-shortcuts-vs-simulated-hotkeys) for details.
+`shortcutID` | `""` | On some platforms, Kando can not bind shortcuts directly. In this case, you can use this property to assign an ID which can be used in the global shortcut configuration of your desktop environment. This should be lowercase and contain only ASCII characters and dashes. For example, `"main-trigger"`.
+`root` | _mandatory_ | The root menu item of the menu given as a Menu Item Description. See below for details.
+`centered` | `false` | Whether the menu should be centered on the screen. If this is `false`, the menu will be opened at the position of the mouse cursor.
+`conditions` | `{}` | A dictionary of conditions which must be met for the menu to be shown. See below for details.
+
+### Menu Conditions
+
+The `conditions` property of a menu description can contain a dictionary of conditions.
+Only if all conditions are met, the menu will be shown.
+
+Property | Default Value | Description
+-------- | ------------- | -----------
+`appName` | `""` | The name of the application which must be focused for the menu to be shown. If it is a simple string, the condition is met if the name of the focused application contains the given string (case-insensitive). If the string starts with a `/`, it is interpreted as a regular expression.
+`windowName` | `""` | The name of the window which must be focused for the menu to be shown. It is interpreted in the same way as `appName`.
+`screenArea` | `{}` | A dictionary with the optional properties `xMin`, `xMax`, `yMin`, and `yMax`. The menu will only be shown if the mouse cursor is within the given screen area. The values are given in pixels and are relative to the top-left corner of the screen. If a value is not given, the area is unbounded in this direction.
+
+### Menu Item Descriptions
+
+The layout of the menu is described by a tree of menu items.
+Each menu item is a JSON object with the following properties:
+
+Property | Default Value | Description
+-------- | ------------- | -----------
+`name` | `"undefined"` | The name of the menu item. This is shown in the center of the menu when the item is hovered. The name of the root item defines the name of the menu.
+`iconTheme` | `""` | For now, this can either be `"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, or `"emoji"`. With the first, you can use icons from [Google's Material Symbols](https://fonts.google.com/icons). With the second or third, you can use any icon from [Simple Icons](https://simpleicons.org/).
+`icon` | `""` | The name of the icon from the given icon theme or an emoji like `"🚀"`.
+`angle` | _auto_ | If given, this defines the angle of the menu item in degrees. If this is not given, the angle is calculated automatically. 0° means that the item is at the top of the menu, 90° means that the item is on the right side of the menu, and so on. All sibling items are evenly distributed around the items with given angles.
+`type` | `"submenu"` | The type of the menu item. There are several types available. See below for details.
+`data` | `{}` | Depending on the type of the item, this can contain additional data. See below for details.
+`children` | `[]` | If the menu item is a submenu, this contains a list of child items. See below for details.
+
+### Menu Item Types
+
+For now, the `type` property of a menu item can be one of the following values.
+New types will be added in the future.
+
+#### `"submenu"`
+This is the default type.
+It is used to create a submenu.
+The `children` property of the menu item must contain a list of child items.
+
+#### `"command"`
+This type is used to execute a shell command.
+The `data` property of the menu item must contain a `command` property which contains the shell command to execute.
+The optional `delayed` property will ensure that the command is executed _after_ the Kando window is closed.
+This can be useful if the command targets another window.
+For instance, this menu item will open Inkscape on Linux:
+```json
+{
+  "name": "Inkscape",
+  "icon": "inkscape",
+  "iconTheme": "simple-icons",
+  "type": "command",
+  "data": {
+    "command": "/usr/bin/inkscape",
+    "delayed": false
+  }
+}
+```
+
+#### `"uri"`
+This type is used to open any kind of URI.
+The `data` property of the menu item must contain a `uri` property which contains the URI to open.
+For instance, this menu item will open GitHub in the default browser:
+```json
+{
+  "name": "GitHub",
+  "icon": "github",
+  "iconTheme": "simple-icons",
+  "type": "uri",
+  "data": {
+    "uri": "https://github.com"
+  }
+}
+```
+
+#### `"hotkey"`
+This type is used to simulate simple keyboard events.
+The `data` property of the menu item must contain a `hotkey` property which contains the hotkey to simulate.
+See [Menu Shortcuts vs.
+Simulated Hotkeys](configuring.md#menu-shortcuts-vs-simulated-hotkeys) for details on the format of the `hotkey` property.
+The optional `delayed` property will ensure that the hotkey is simulated _after_ the Kando window is closed.
+This can be used if the hotkey should be captured by another window.
+For instance, this menu item will paste the clipboard content:
+```json
+{
+  "name": "Paste",
+  "icon": "content_paste_go",
+  "iconTheme": "material-symbols-rounded",
+  "type": "hotkey",
+  "data": {
+    "hotkey": "ControlLeft+KeyV",
+    "delayed": true
+  }
+}
+```
+
+#### `"macro"`
+This type is used to simulate a more comples sequence of keyboard events.
+The `data` property of the menu item must contain a `macro` property which contains the sequence of key codes to simulate.
+See [Menu Shortcuts vs. Simulated Hotkeys](configuring.md#menu-shortcuts-vs-simulated-hotkeys) for details on key code format.
+The optional `delayed` property will ensure that the macro is simulated _after_ the Kando window is closed.
+This can be used if the macro should be captured by another window.
+For instance, this menu item will type "Hi" on most keyboard layouts:
+```json
+{
+  "type": "macro",
+  "data": {
+    "macro": [
+      {
+        "type": "keyDown",
+        "key": "ShiftLeft",
+        "delay": 10
+      },
+      {
+        "type": "keyDown",
+        "key": "KeyH",
+        "delay": 10
+      },
+      {
+        "type": "keyUp",
+        "key": "KeyH",
+        "delay": 10
+      },
+      {
+        "type": "keyUp",
+        "key": "ShiftLeft",
+        "delay": 10
+      },
+      {
+        "type": "keyDown",
+        "key": "KeyI",
+        "delay": 10
+      },
+      {
+        "type": "keyUp",
+        "key": "KeyI",
+        "delay": 10
+      }
+    ],
+    "delayed": true
+  },
+  "name": "Hello World",
+  "icon": "keyboard_keys",
+  "iconTheme": "material-symbols-rounded"
+}
+```
+
+
+<p align="center"><img src ="img/hr.svg" /></p>
+
+<p align="center">
+  <img src="img/nav-space.svg"/>
+  <a href="configuring.md"><img src ="img/left-arrow.png"/> Configuring Kando</a>
+  <img src="img/nav-space.svg"/>
+  <a href="README.md"><img src ="img/home.png"/> Index</a>
+  <img src="img/nav-space.svg"/>
+  <img src="img/nav-space.svg"/>
+  <img src="img/nav-space.svg"/>
+</p>

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -92,7 +92,7 @@ Each menu item is a JSON object with the following properties:
 Property | Default Value | Description
 -------- | ------------- | -----------
 `name` | `"undefined"` | The name of the menu item. This is shown in the center of the menu when the item is hovered. The name of the root item defines the name of the menu.
-`iconTheme` | `""` | For now, this can either be `"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, or `"emoji"`. With the first, you can use icons from [Google's Material Symbols](https://fonts.google.com/icons). With the second or third, you can use any icon from [Simple Icons](https://simpleicons.org/).
+`iconTheme` | `""` | This can either be one of the built-in icon themes (`"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, or `"emoji"`) or a subdirectory of the `icon-themes` subdirectory in Kando's config directory. The built-in icon themes use icons from [Google's Material Symbols](https://fonts.google.com/icons) or [Simple Icons](https://simpleicons.org/) respectively.
 `icon` | `""` | The name of the icon from the given icon theme or an emoji like `"🚀"`.
 `angle` | _auto_ | If given, this defines the angle of the menu item in degrees. If this is not given, the angle is calculated automatically. 0° means that the item is at the top of the menu, 90° means that the item is on the right side of the menu, and so on. All sibling items are evenly distributed around the items with given angles.
 `type` | `"submenu"` | The type of the menu item. There are several types available. See below for details.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -21,19 +21,35 @@ There are three ways to open the menu editor:
 In the editor, you can create new menus, and edit existing menus.
 Drag new items from the toolbar to the menu preview, reorder them, and change their properties on the right side of the screen.
 
-## Tips for Creating Efficient Menu Layouts
+## Tips for Creating Efficient Menu Layouts :rocket:
 
 When designing your own menus, keep the following tips in mind:
 * **Avoid too many items in a single menu.** Instead, create submenus. Eight items per menu is a good rule of thumb, and you should never have more than twelve items in a single menu.
 * **Deeply nested menus are not a problem.** Kando is designed to handle deeply nested menus. You can use the marking mode to quickly select items which are in subsubsubmenus.
 * **Use the fixed-angle locks to create a clean layout.** Even if you have an odd number of items, you can use fixed angles to lock items to the top, bottom, left, or right side of the menu.
 
-## Adding Custom Icon Themes
+## Adding Custom Icon Themes :sparkles:
 
 To add your own icons to Kando, follow these steps:
-1. Create a new `icon-themes` directory in Kando's configuration directory if it does not yet exist.
+1. Create a new `icon-themes` directory in Kando's configuration directory if it does not yet exist. Depending on your OS, this will be the following locations:
+    * <img height="14" width="26" src="https://cdn.simpleicons.org/windows" /> Windows: `%appdata%\kando\icon-themes`
+    * <img height="14" width="26" src="https://cdn.simpleicons.org/apple" /> macOS: `~/Library/Application Support/kando/icon-themes`
+    * <img height="14" width="26" src="https://cdn.simpleicons.org/linux/black" /> Linux: `~/.config/kando/icon-themes`
+2. Create a new directory for your icon theme in the `icon-themes` directory. You can give it any name you like.
+3. Add your icons to the new directory. The icons can be in various formats, but we recommend using SVG files.
+4. **Restart Kando.** Icon themes are only loaded when Kando starts.
+5. Select your icon theme in the icon-theme dropdown in the icon picker in Kando's menu editor.
 
-## Menu Shortcuts vs. Simulated Hotkeys
+### Some Tips for Creating Icon Themes
+
+* You can organize your icons in subdirectories. Kando will load them recursively. The directory will be part of the icon's name and therefore you can use the search bar to filter by directory.
+* There are many great icon sets available on the internet. Here are some which you could try:
+  * [Numix Circle](https://github.com/numixproject/numix-icon-theme-circle)
+  * [Papirus](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme)
+  * [Tela](https://github.com/vinceliuice/Tela-icon-theme)
+
+
+## Menu Shortcuts vs. Simulated Hotkeys :keyboard:
 
 With Kando, you can bind a menu to a keyboard shortcut and use menu items to simulate keyboard hotkeys or macros.
 This is a bit confusing as all are configured similarly, but use different formats.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -10,17 +10,9 @@ SPDX-License-Identifier: CC-BY-4.0
 Kando comes with an example menu which you can use to get started.
 However, you should soon adapt the menu to your needs and create your own menus.
 
-When designing your own menus, keep the following tips in mind:
-* **Avoid too many items in a single menu.** Instead, create submenus. Eight items per menu is a good rule of thumb, and you should never have more than twelve items in a single menu.
-* **Deeply nested menus are not a problem.** Kando is designed to handle deeply nested menus. You can use the marking mode to quickly select items which are in subsubsubmenus.
-* **Use the fixed-angle locks to create a clean layout.** Even if you have an odd number of items, you can use fixed angles to lock items to the top, bottom, left, or right side of the menu.
-
-
-## The Menu Editor
-
 <img src="img/settings-button.jpg" align="right" width="150px"></img>
 
-Kando comes with a graphical menu editor which allows you to create and edit your own menus.
+Kando comes with a **graphical menu editor** which allows you to create and edit your own menus.
 There are three ways to open the menu editor:
 1. **When a menu is shown:** Click the gear icon in the bottom right corner of the screen.
 2. **From the system tray:** Right-click the Kando icon and select "Show Settings".
@@ -29,216 +21,17 @@ There are three ways to open the menu editor:
 In the editor, you can create new menus, and edit existing menus.
 Drag new items from the toolbar to the menu preview, reorder them, and change their properties on the right side of the screen.
 
-## The Configuration Files
+## Tips for Creating Efficient Menu Layouts
 
-All configuration is stored in **two configuration files** JSON files which you can also edit manually.
-`config.json` stores the general configuration of the application and `menus.json` stores the configuration of the individual menus.
-Depending on your platform, the configuration files are located in different directories:
+When designing your own menus, keep the following tips in mind:
+* **Avoid too many items in a single menu.** Instead, create submenus. Eight items per menu is a good rule of thumb, and you should never have more than twelve items in a single menu.
+* **Deeply nested menus are not a problem.** Kando is designed to handle deeply nested menus. You can use the marking mode to quickly select items which are in subsubsubmenus.
+* **Use the fixed-angle locks to create a clean layout.** Even if you have an odd number of items, you can use fixed angles to lock items to the top, bottom, left, or right side of the menu.
 
-* <img height="14" width="26" src="https://cdn.simpleicons.org/windows" /> Windows: `%appdata%\kando\`
-* <img height="14" width="26" src="https://cdn.simpleicons.org/apple" /> macOS: `~/Library/Application Support/kando/`
-* <img height="14" width="26" src="https://cdn.simpleicons.org/linux/black" /> Linux: `~/.config/kando/`
+## Adding Custom Icon Themes
 
-**📝 JSON Format**: Both configuration files are JSON files. You can edit them with any text editor.
-
-**🔥 Hot Reloading:** Whenever you save a file, Kando will automatically reload the configuration.
-
-**✅ Validation:** Kando will validate the configuration files and [print errors to the console](installing.md#running-kando-from-the-command-line) if it finds any. In this case, the configuration will not be reloaded. If a configuration file is invalid at startup, Kando will use the default configuration instead.
-
-
-### The General Configuration: `config.json`
-
-This file contains the general configuration of Kando.
-
-Property | Default Value | Description
--------- | ------------- | -----------
-`sidebarVisible` | `true` | Whether the left sidebar is currently visible.
-`zoomFactor` | `1.0` | The zoom factor of the menu. This can be used to scale the menu on high-resolution screens.
-`enableVersionCheck` | `true` | If set to `true`, Kando will check for new version regularly, and show a notification if a new version is available.
-
-### The Menu Configuration: `menus.json`
-
-This file contains the configuration of the individual menus.
-There are two top-level JSON objects: `menus` contains a list of _Menu Descriptions_ and `templates` contains a list of _Menu Descriptions_ or _Menu Item Descriptions_.
-
-```js
-{
-  "menus": [
-    {
-      // First Menu Description.
-      // ...
-    },
-    {
-      // Second Menu Description.
-      // ...
-    },
-    // ...
-  ],
-  "templates": [
-    // Can contain Menu Descriptions and Menu Item Descriptions.
-  ]
-}
-```
-
-> [!TIP]
-> You can have a look at a the example menu configurations [here](https://github.com/kando-menu/kando/tree/main/src/main/example-menus)!
-
-
-#### Menu Descriptions
-
-The items in the `menus` list are called menu descriptions.
-They are JSON objects with the following properties:
-
-Property | Default Value | Description
--------- | ------------- | -----------
-`shortcut` | `""` | The shortcut which opens the menu. This is a string which can contain multiple keys separated by `+`. For example, `"Ctrl+Shift+K"` or `"Cmd+Shift+K"`. If empty, the menu will not have a shortcut. See [Menu Shortcuts vs. Simulated Hotkeys](#menu-shortcuts-vs-simulated-hotkeys) for details.
-`shortcutID` | `""` | On some platforms, Kando can not bind shortcuts directly. In this case, you can use this property to assign an ID which can be used in the global shortcut configuration of your desktop environment. This should be lowercase and contain only ASCII characters and dashes. For example, `"main-trigger"`.
-`root` | _mandatory_ | The root menu item of the menu given as a Menu Item Description. See below for details.
-`centered` | `false` | Whether the menu should be centered on the screen. If this is `false`, the menu will be opened at the position of the mouse cursor.
-`conditions` | `{}` | A dictionary of conditions which must be met for the menu to be shown. See below for details.
-
-#### Menu Conditions
-
-The `conditions` property of a menu description can contain a dictionary of conditions.
-Only if all conditions are met, the menu will be shown.
-
-Property | Default Value | Description
--------- | ------------- | -----------
-`appName` | `""` | The name of the application which must be focused for the menu to be shown. If it is a simple string, the condition is met if the name of the focused application contains the given string (case-insensitive). If the string starts with a `/`, it is interpreted as a regular expression.
-`windowName` | `""` | The name of the window which must be focused for the menu to be shown. It is interpreted in the same way as `appName`.
-`screenArea` | `{}` | A dictionary with the optional properties `xMin`, `xMax`, `yMin`, and `yMax`. The menu will only be shown if the mouse cursor is within the given screen area. The values are given in pixels and are relative to the top-left corner of the screen. If a value is not given, the area is unbounded in this direction.
-
-#### Menu Item Descriptions
-
-The layout of the menu is described by a tree of menu items.
-Each menu item is a JSON object with the following properties:
-
-Property | Default Value | Description
--------- | ------------- | -----------
-`name` | `"undefined"` | The name of the menu item. This is shown in the center of the menu when the item is hovered. The name of the root item defines the name of the menu.
-`iconTheme` | `""` | For now, this can either be `"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, or `"emoji"`. With the first, you can use icons from [Google's Material Symbols](https://fonts.google.com/icons). With the second or third, you can use any icon from [Simple Icons](https://simpleicons.org/).
-`icon` | `""` | The name of the icon from the given icon theme or an emoji like `"🚀"`.
-`angle` | _auto_ | If given, this defines the angle of the menu item in degrees. If this is not given, the angle is calculated automatically. 0° means that the item is at the top of the menu, 90° means that the item is on the right side of the menu, and so on. All sibling items are evenly distributed around the items with given angles.
-`type` | `"submenu"` | The type of the menu item. There are several types available. See below for details.
-`data` | `{}` | Depending on the type of the item, this can contain additional data. See below for details.
-`children` | `[]` | If the menu item is a submenu, this contains a list of child items. See below for details.
-
-#### Menu Item Types
-
-For now, the `type` property of a menu item can be one of the following values.
-New types will be added in the future.
-
-##### `"submenu"`
-This is the default type.
-It is used to create a submenu.
-The `children` property of the menu item must contain a list of child items.
-
-##### `"command"`
-This type is used to execute a shell command.
-The `data` property of the menu item must contain a `command` property which contains the shell command to execute.
-The optional `delayed` property will ensure that the command is executed _after_ the Kando window is closed.
-This can be useful if the command targets another window.
-For instance, this menu item will open Inkscape on Linux:
-```json
-{
-  "name": "Inkscape",
-  "icon": "inkscape",
-  "iconTheme": "simple-icons",
-  "type": "command",
-  "data": {
-    "command": "/usr/bin/inkscape",
-    "delayed": false
-  }
-}
-```
-
-##### `"uri"`
-This type is used to open any kind of URI.
-The `data` property of the menu item must contain a `uri` property which contains the URI to open.
-For instance, this menu item will open GitHub in the default browser:
-```json
-{
-  "name": "GitHub",
-  "icon": "github",
-  "iconTheme": "simple-icons",
-  "type": "uri",
-  "data": {
-    "uri": "https://github.com"
-  }
-}
-```
-
-##### `"hotkey"`
-This type is used to simulate simple keyboard events.
-The `data` property of the menu item must contain a `hotkey` property which contains the hotkey to simulate.
-See [Menu Shortcuts vs.
-Simulated Hotkeys](#menu-shortcuts-vs-simulated-hotkeys) for details on the format of the `hotkey` property.
-The optional `delayed` property will ensure that the hotkey is simulated _after_ the Kando window is closed.
-This can be used if the hotkey should be captured by another window.
-For instance, this menu item will paste the clipboard content:
-```json
-{
-  "name": "Paste",
-  "icon": "content_paste_go",
-  "iconTheme": "material-symbols-rounded",
-  "type": "hotkey",
-  "data": {
-    "hotkey": "ControlLeft+KeyV",
-    "delayed": true
-  }
-}
-```
-
-##### `"macro"`
-This type is used to simulate a more comples sequence of keyboard events.
-The `data` property of the menu item must contain a `macro` property which contains the sequence of key codes to simulate.
-See [Menu Shortcuts vs. Simulated Hotkeys](#menu-shortcuts-vs-simulated-hotkeys) for details on key code format.
-The optional `delayed` property will ensure that the macro is simulated _after_ the Kando window is closed.
-This can be used if the macro should be captured by another window.
-For instance, this menu item will type "Hi" on most keyboard layouts:
-```json
-{
-  "type": "macro",
-  "data": {
-    "macro": [
-      {
-        "type": "keyDown",
-        "key": "ShiftLeft",
-        "delay": 10
-      },
-      {
-        "type": "keyDown",
-        "key": "KeyH",
-        "delay": 10
-      },
-      {
-        "type": "keyUp",
-        "key": "KeyH",
-        "delay": 10
-      },
-      {
-        "type": "keyUp",
-        "key": "ShiftLeft",
-        "delay": 10
-      },
-      {
-        "type": "keyDown",
-        "key": "KeyI",
-        "delay": 10
-      },
-      {
-        "type": "keyUp",
-        "key": "KeyI",
-        "delay": 10
-      }
-    ],
-    "delayed": true
-  },
-  "name": "Hello World",
-  "icon": "keyboard_keys",
-  "iconTheme": "material-symbols-rounded"
-}
-```
+To add your own icons to Kando, follow these steps:
+1. Create a new `icon-themes` directory in Kando's configuration directory if it does not yet exist.
 
 ## Menu Shortcuts vs. Simulated Hotkeys
 
@@ -462,6 +255,6 @@ Note that not all key codes are available on all platforms.
   <img src="img/nav-space.svg"/>
   <a href="README.md"><img src ="img/home.png"/> Index</a>
   <img src="img/nav-space.svg"/>
-  <img src="img/nav-space.svg"/>
+  <a href="config-files.md">The Configuration Files <img src ="img/right-arrow.png"/></a>
   <img src="img/nav-space.svg"/>
 </p>

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -271,6 +271,6 @@ Note that not all key codes are available on all platforms.
   <img src="img/nav-space.svg"/>
   <a href="README.md"><img src ="img/home.png"/> Index</a>
   <img src="img/nav-space.svg"/>
-  <a href="config-files.md">The Configuration Files <img src ="img/right-arrow.png"/></a>
+  <a href="config-files.md">Config Files <img src ="img/right-arrow.png"/></a>
   <img src="img/nav-space.svg"/>
 </p>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,5 +68,5 @@ When a new version is released, this section will be marked as released and a ta
   <img src="img/nav-space.svg"/>
   <a href="README.md"><img src ="img/home.png"/> Index</a>
   <img src="img/nav-space.svg"/>
-  <a href="installing.md">Building Kando <img src ="img/right-arrow.png"/></a>
+  <a href="installing.md">Installing Kando <img src ="img/right-arrow.png"/></a>
 </p>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -59,6 +59,13 @@ const config: ForgeConfig = {
   ],
   plugins: [
     new WebpackPlugin({
+      // We add 'img-src 'self' file: data:' to the default-src directive to allow loading
+      // images from the file system and data URLs. This is only necessary for the
+      // development build. In the production build, webpack will serve the app from a file
+      // instead of a server in which case electron will not enforce the Content Security
+      // Policy.
+      devContentSecurityPolicy:
+        "default-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:; img-src 'self' file: data:",
       mainConfig,
       renderer: {
         config: rendererConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@types/bootstrap": "^5.2.10",
         "@types/lodash.isequal": "^4.5.8",
+        "@types/mime-types": "^2.1.4",
         "bootstrap": "^5.3.1",
         "chokidar": "^3.6.0",
         "commander": "^12.0.0",
@@ -24,6 +25,7 @@
         "lodash.isequal": "^4.5.0",
         "match-sorter": "^6.3.4",
         "material-symbols": "^0.20.0",
+        "mime-types": "^2.1.35",
         "node-addon-api": "^8.0.0",
         "octokit": "^4.0.2",
         "simple-icons-font": "^13.0.0"
@@ -1821,6 +1823,11 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -8966,7 +8973,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8975,7 +8981,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@popperjs/core": "^2.11.8",
     "@types/bootstrap": "^5.2.10",
     "@types/lodash.isequal": "^4.5.8",
+    "@types/mime-types": "^2.1.4",
     "bootstrap": "^5.3.1",
     "chokidar": "^3.6.0",
     "commander": "^12.0.0",
@@ -71,6 +72,7 @@
     "lodash.isequal": "^4.5.0",
     "match-sorter": "^6.3.4",
     "material-symbols": "^0.20.0",
+    "mime-types": "^2.1.35",
     "node-addon-api": "^8.0.0",
     "octokit": "^4.0.2",
     "simple-icons-font": "^13.0.0"

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -38,6 +38,8 @@ declare global {
         getCurrentMenu: () => Promise<number>;
       };
       getBackendInfo: () => Promise<IBackendInfo>;
+      getUserIconThemes: () => Promise<Array<string>>;
+      listUserIcons: (string: iconTheme) => Promise<Array<string>>;
       showDevTools: () => void;
       movePointer: (dist: IVec2) => void;
       log: (message: string) => void;

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -52,6 +52,7 @@ declare global {
         ) => void
       ) => void;
       showEditor: (func: (editorOptions: IShowEditorOptions) => void) => void;
+      hideEditor: (func: () => void) => void;
       showUpdateAvailableButton: (func: () => void) => void;
       hoverItem: (path: string) => void;
       unhoverItem: (path: string) => void;

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -38,6 +38,7 @@ declare global {
         getCurrentMenu: () => Promise<number>;
       };
       getBackendInfo: () => Promise<IBackendInfo>;
+      getUserIconThemeDirectory: () => Promise<string>;
       getUserIconThemes: () => Promise<Array<string>>;
       listUserIcons: (string: iconTheme) => Promise<Array<string>>;
       showDevTools: () => void;

--- a/src/common/icon-theme-registry.ts
+++ b/src/common/icon-theme-registry.ts
@@ -12,6 +12,7 @@ import { SimpleIconsTheme } from './icon-themes/simple-icons-theme';
 import { SimpleIconsColoredTheme } from './icon-themes/simple-icons-colored-theme';
 import { MaterialSymbolsTheme } from './icon-themes/material-symbols-theme';
 import { EmojiTheme } from './icon-themes/emoji-theme';
+import { UserIconTheme } from './icon-themes/user-icon-theme';
 
 /**
  * This interface describes an icon theme. An icon theme is a collection of icons that can
@@ -48,7 +49,7 @@ export interface IIconTheme {
  */
 export class IconThemeRegistry {
   /** The singleton instance of this class. */
-  private static instance: IconThemeRegistry = null;
+  private static instance: IconThemeRegistry = new IconThemeRegistry();
 
   /** This map contains all available icon themes. The keys are the type names. */
   private iconThemes: Map<string, IIconTheme> = new Map();
@@ -62,6 +63,16 @@ export class IconThemeRegistry {
     this.iconThemes.set('simple-icons-colored', new SimpleIconsColoredTheme());
     this.iconThemes.set('material-symbols-rounded', new MaterialSymbolsTheme());
     this.iconThemes.set('emoji', new EmojiTheme());
+
+    // Add an icon theme for all icon themes in the user's icon theme directory.
+    Promise.all([
+      window.api.getUserIconThemeDirectory(),
+      window.api.getUserIconThemes(),
+    ]).then(([directory, themes]) => {
+      for (const theme of themes) {
+        this.iconThemes.set(theme, new UserIconTheme(directory, theme));
+      }
+    });
   }
 
   /**
@@ -70,9 +81,6 @@ export class IconThemeRegistry {
    * @returns The singleton instance of this class.
    */
   public static getInstance(): IconThemeRegistry {
-    if (IconThemeRegistry.instance === null) {
-      IconThemeRegistry.instance = new IconThemeRegistry();
-    }
     return IconThemeRegistry.instance;
   }
 

--- a/src/common/icon-theme-registry.ts
+++ b/src/common/icon-theme-registry.ts
@@ -58,6 +58,9 @@ export class IconThemeRegistry {
   /** This is the fallback icon theme that is used if no valid icon theme is selected. */
   private fallbackTheme: IIconTheme = new FallbackTheme();
 
+  /** The directory where the user's icon themes are stored. */
+  private _userIconThemeDirectory = '';
+
   /**
    * This is a singleton class. The constructor is private. Use `getInstance` to get the
    * instance of this class.
@@ -73,6 +76,7 @@ export class IconThemeRegistry {
       window.api.getUserIconThemeDirectory(),
       window.api.getUserIconThemes(),
     ]).then(([directory, themes]) => {
+      this._userIconThemeDirectory = directory;
       for (const theme of themes) {
         this.iconThemes.set(theme, new UserIconTheme(directory, theme));
       }
@@ -86,6 +90,15 @@ export class IconThemeRegistry {
    */
   public static getInstance(): IconThemeRegistry {
     return IconThemeRegistry.instance;
+  }
+
+  /**
+   * Use this method to get the directory where the user's icon themes are stored.
+   *
+   * @returns The directory where the user's icon themes are stored.
+   */
+  get userIconThemeDirectory(): string {
+    return this._userIconThemeDirectory;
   }
 
   /**

--- a/src/common/icon-theme-registry.ts
+++ b/src/common/icon-theme-registry.ts
@@ -13,6 +13,7 @@ import { SimpleIconsColoredTheme } from './icon-themes/simple-icons-colored-them
 import { MaterialSymbolsTheme } from './icon-themes/material-symbols-theme';
 import { EmojiTheme } from './icon-themes/emoji-theme';
 import { UserIconTheme } from './icon-themes/user-icon-theme';
+import { FallbackTheme } from './icon-themes/fallback-theme';
 
 /**
  * This interface describes an icon theme. An icon theme is a collection of icons that can
@@ -53,6 +54,9 @@ export class IconThemeRegistry {
 
   /** This map contains all available icon themes. The keys are the type names. */
   private iconThemes: Map<string, IIconTheme> = new Map();
+
+  /** This is the fallback icon theme that is used if no valid icon theme is selected. */
+  private fallbackTheme: IIconTheme = new FallbackTheme();
 
   /**
    * This is a singleton class. The constructor is private. Use `getInstance` to get the
@@ -98,9 +102,10 @@ export class IconThemeRegistry {
    * Use this method to get a specific icon theme.
    *
    * @param key The unique key of the icon theme.
-   * @returns The icon theme with the given key.
+   * @returns The icon theme with the given key. If no icon theme with the given key
+   *   exists, a fallback icon theme is returned.
    */
   public getTheme(key: string): IIconTheme {
-    return this.iconThemes.get(key);
+    return this.iconThemes.get(key) || this.fallbackTheme;
   }
 }

--- a/src/common/icon-themes/fallback-theme.ts
+++ b/src/common/icon-themes/fallback-theme.ts
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { IIconTheme } from '../icon-theme-registry';
+
+/**
+ * This class implements an icon theme that is used if the user has not selected a valid
+ * icon theme.
+ */
+export class FallbackTheme implements IIconTheme {
+  /** Not required as this is not a user-selectable theme. */
+  get name() {
+    return '';
+  }
+
+  /** Not required as this is not a user-selectable theme. */
+  public async listIcons(): Promise<Array<string>> {
+    return [];
+  }
+
+  /**
+   * Creates a div with a question mark icon.
+   *
+   * @returns A div element that contains the icon.
+   */
+  createDiv() {
+    const containerDiv = document.createElement('div');
+    containerDiv.classList.add('icon-container');
+
+    const iconDiv = document.createElement('i');
+    containerDiv.appendChild(iconDiv);
+
+    iconDiv.classList.add('emoji-icon');
+    iconDiv.innerText = '❓';
+
+    return containerDiv;
+  }
+}

--- a/src/common/icon-themes/user-icon-theme.ts
+++ b/src/common/icon-themes/user-icon-theme.ts
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { matchSorter } from 'match-sorter';
+
+import { IIconTheme } from '../icon-theme-registry';
+
+/**
+ * This class is used for custom icon themes loaded from the icon-themes subdirectory of
+ * Kando's config directory.
+ */
+export class UserIconTheme implements IIconTheme {
+  /** This array contains all available icon names. It is initialized in the constructor. */
+  private iconNames: Array<string> = [];
+
+  /**
+   * Creates a new UserIconTheme.
+   *
+   * @param directory This is the path to the icon-themes directory in Kando's config
+   *   directory.
+   * @param subdirectory This is the name of the icon theme's subdirectory in the
+   *   icon-themes directory.
+   */
+  constructor(
+    private directory: string,
+    private subdirectory: string
+  ) {
+    window.api.listUserIcons(this.subdirectory).then((icons: Array<string>) => {
+      this.iconNames = icons;
+    });
+  }
+
+  /**
+   * The name of the icon corresponds to the name of the directory in the icon-themes
+   * subdirectory of Kando's config directory.
+   */
+  get name() {
+    return this.subdirectory;
+  }
+
+  /**
+   * Returns a list icons from this theme that match the given search term.
+   *
+   * @param searchTerm The search term to filter the icons.
+   * @returns An array of icon names that match the search term.
+   */
+  public async listIcons(searchTerm: string) {
+    return matchSorter(this.iconNames, searchTerm);
+  }
+
+  /**
+   * Creates a div element that contains the icon with the given name.
+   *
+   * @param icon One of the icons returned by `listIcons`.
+   * @returns A div element that contains the icon.
+   */
+  createDiv(icon: string) {
+    const containerDiv = document.createElement('div');
+    containerDiv.classList.add('icon-container');
+
+    const iconDiv = document.createElement('img');
+    containerDiv.appendChild(iconDiv);
+
+    iconDiv.src = `file://${this.directory}/${this.subdirectory}/${icon}`;
+
+    return containerDiv;
+  }
+}

--- a/src/common/icon-themes/user-icon-theme.ts
+++ b/src/common/icon-themes/user-icon-theme.ts
@@ -66,9 +66,10 @@ export class UserIconTheme implements IIconTheme {
     containerDiv.classList.add('icon-container');
 
     const iconDiv = document.createElement('img');
-    containerDiv.appendChild(iconDiv);
-
     iconDiv.src = `file://${this.directory}/${this.subdirectory}/${icon}`;
+    iconDiv.draggable = false;
+
+    containerDiv.appendChild(iconDiv);
 
     return containerDiv;
   }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -571,6 +571,11 @@ export class KandoApp {
       return this.backend.getBackendInfo();
     });
 
+    // Allow the renderer to retrieve the path to the user's icon theme directory.
+    ipcMain.handle('get-user-icon-theme-directory', () => {
+      return path.join(app.getPath('userData'), 'icon-themes');
+    });
+
     // Allow the renderer to retrieve all subdirectories of the icon-themes directory.
     ipcMain.handle('get-user-icon-themes', async () => {
       return new Promise<string[]>((resolve, reject) => {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -514,7 +514,7 @@ export class KandoApp {
     // If the user clicks on a link, we close Kando's window and open the link in the
     // default browser.
     this.window.webContents.setWindowOpenHandler(({ url }) => {
-      this.hideWindow();
+      this.window.webContents.send('hide-editor');
       shell.openExternal(url);
       return { action: 'deny' };
     });

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -471,6 +471,10 @@ export class KandoApp {
       webPreferences: {
         contextIsolation: true,
         sandbox: true,
+        // Electron only allows loading local resources from apps loaded from the file
+        // system. In development mode, the app is loaded from the webpack dev server.
+        // Hence, we have to disable webSecurity in development mode.
+        webSecurity: process.env.NODE_ENV !== 'development',
         preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
       },
       transparent: true,

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -595,11 +595,17 @@ export class KandoApp {
 
     // Allow the renderer to retrieve all subdirectories of the icon-themes directory.
     ipcMain.handle('get-user-icon-themes', async () => {
-      return new Promise<string[]>((resolve, reject) => {
+      return new Promise<string[]>((resolve) => {
         const iconThemesDir = path.join(app.getPath('userData'), 'icon-themes');
         fs.readdir(iconThemesDir, { withFileTypes: true }, (err, dirents) => {
+          // We ignore ENOENT errors as they just mean that the directory does not exist.
+          // All other errors are printed to the console.
           if (err) {
-            reject(err);
+            if (err.code !== 'ENOENT') {
+              console.error(err);
+            }
+
+            resolve([]);
             return;
           }
 
@@ -614,11 +620,12 @@ export class KandoApp {
 
     // Allow the renderer to retrieve all files in the given icon theme directory.
     ipcMain.handle('list-user-icons', async (event, iconTheme: string) => {
-      return new Promise<string[]>((resolve, reject) => {
+      return new Promise<string[]>((resolve) => {
         const iconDir = path.join(app.getPath('userData'), 'icon-themes', iconTheme);
         fs.readdir(iconDir, { withFileTypes: true, recursive: true }, (err, files) => {
           if (err) {
-            reject(err);
+            console.error(err);
+            resolve([]);
             return;
           }
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -599,7 +599,7 @@ export class KandoApp {
     ipcMain.handle('list-user-icons', async (event, iconTheme: string) => {
       return new Promise<string[]>((resolve, reject) => {
         const iconDir = path.join(app.getPath('userData'), 'icon-themes', iconTheme);
-        fs.readdir(iconDir, { withFileTypes: true }, (err, files) => {
+        fs.readdir(iconDir, { withFileTypes: true, recursive: true }, (err, files) => {
           if (err) {
             reject(err);
             return;
@@ -615,7 +615,10 @@ export class KandoApp {
             return mimeType && mimeType.startsWith('image/');
           });
 
-          resolve(files.map((file) => file.name));
+          // We return the relative path of the files to the icon theme directory.
+          resolve(
+            files.map((file) => path.relative(iconDir, path.join(file.path, file.name)))
+          );
         });
       });
     });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -36,6 +36,12 @@ window.api.getBackendInfo().then((info) => {
     editor.enterEditMode();
   });
 
+  // Hide the editor when the main process requests it.
+  window.api.hideEditor(() => {
+    editor.hide();
+    window.api.cancelSelection();
+  });
+
   // Show the update available button when the main process requests it.
   window.api.showUpdateAvailableButton(() => {
     document.getElementById('sidebar-show-new-version-button').classList.remove('d-none');

--- a/src/renderer/editor/common/style/icon-container.scss
+++ b/src/renderer/editor/common/style/icon-container.scss
@@ -30,6 +30,12 @@
     font-size: 75cqi;
     font-style: normal;
   }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 }
 
 #kando-editor .inline-icon {

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -80,7 +80,18 @@ export class IconPicker extends EventEmitter {
     // template below. The data object contains an array of objects with the keys `name`
     // and `key`. The `name` is the display name of the theme and the `key` is the key
     // that is used to identify the theme in the IconThemeRegistry.
-    const data: { themes: { name: string; key: string }[] } = { themes: [] };
+    const data = {
+      heading: 'Select an Icon',
+      subheading:
+        'You can add your own icon collections by putting a folder with icons into %1. Learn more <a %2>here</a>.'
+          .replace('%1', IconThemeRegistry.getInstance().userIconThemeDirectory)
+          .replace(
+            '%2',
+            'href="https://github.com/kando-menu/kando/blob/main/docs/configuring.md" target="_blank"'
+          ),
+
+      themes: new Array<{ name: string; key: string }>(),
+    };
     const themes = IconThemeRegistry.getInstance().getThemes();
     themes.forEach((theme, key) => {
       data.themes.push({ name: theme.name, key });
@@ -271,7 +282,7 @@ export class IconPicker extends EventEmitter {
               }
             });
           },
-          { root: scrollbox, delay: 100 }
+          { root: scrollbox, delay: 250, rootMargin: '250px' }
         );
 
         // Observe all icons in the grid. We get the icons by querying the grid for all

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -263,7 +263,7 @@ export class IconPicker extends EventEmitter {
         const scrollbox = this.iconGrid.parentElement.parentElement;
         if (this.selectedIconDiv) {
           scrollbox.scrollTop =
-            this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2;
+            this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2 - 150;
         }
 
         // Create the observer that is used to detect when icons are scrolled into view.

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -56,6 +56,12 @@ export class IconPicker extends EventEmitter {
   /** The observer that is used to detect when icons are scrolled into view. */
   private observer: IntersectionObserver = null;
 
+  /**
+   * The tooltips of the icons in the grid. We need to keep track of them to remove them
+   * when the icon grid is reloaded.
+   */
+  private tooltips: Tooltip[] = [];
+
   /** The icon and theme that were selected when the icon picker was opened. */
   private initialTheme: string = null;
   private initialIcon: string = null;
@@ -165,6 +171,10 @@ export class IconPicker extends EventEmitter {
       this.observer.disconnect();
     }
 
+    // Clear the tooltips.
+    this.tooltips.forEach((tooltip) => tooltip.dispose());
+    this.tooltips = [];
+
     const theme = IconThemeRegistry.getInstance().getTheme(this.themeSelect.value);
     const icons = await theme.listIcons(this.filterInput.value);
 
@@ -196,9 +206,10 @@ export class IconPicker extends EventEmitter {
         fragment.appendChild(iconButton);
 
         // Initialize the tooltip for the newly created icon.
-        new Tooltip(iconButton, {
+        const tooltip = new Tooltip(iconButton, {
           delay: { show: 500, hide: 0 },
         });
+        this.tooltips.push(tooltip);
 
         // When the user clicks an icon, emit the select-icon event and add the
         // selected class to the icon.

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -13,6 +13,15 @@ import { Tooltip } from 'bootstrap';
 
 import { IconThemeRegistry } from '../../../common/icon-theme-registry';
 
+// Extend the IntersectionObserverInit interface to allow for a delay option. This delay
+// was introduced in IntersectionObserver v2 and is for some reason not yet part of the
+// TypeScript definitions.
+declare global {
+  interface IntersectionObserverInit {
+    delay?: number;
+  }
+}
+
 /**
  * This class is responsible for displaying the icon picker of the menu editor. It emits
  * events when the user chooses a new icon. In fact, whenever an icon is clicked at, the
@@ -43,6 +52,9 @@ export class IconPicker extends EventEmitter {
 
   /** When a new loadIcons operation is started, the previous one is aborted. */
   private loadAbortController: AbortController = null;
+
+  /** The observer that is used to detect when icons are scrolled into view. */
+  private observer: IntersectionObserver = null;
 
   /** The icon and theme that were selected when the icon picker was opened. */
   private initialTheme: string = null;
@@ -83,8 +95,8 @@ export class IconPicker extends EventEmitter {
       '#kando-properties-icon-theme-select'
     ) as HTMLSelectElement;
 
-    this.filterInput.addEventListener('input', () => this.updateIconGrid());
-    this.themeSelect.addEventListener('change', () => this.updateIconGrid());
+    this.filterInput.addEventListener('input', () => this.loadIcons());
+    this.themeSelect.addEventListener('change', () => this.loadIcons());
 
     // Close the icon picker when the user clicks the close button.
     const okButton = container.querySelector('#kando-properties-icon-picker-ok');
@@ -114,7 +126,7 @@ export class IconPicker extends EventEmitter {
 
     this.themeSelect.value = theme;
 
-    this.updateIconGrid();
+    this.loadIcons();
   }
 
   /** Hides the icon picker. */
@@ -131,29 +143,14 @@ export class IconPicker extends EventEmitter {
 
   /**
    * Reloads the icons of the currently selected theme and updates the icon grid. The grid
-   * will scroll to the selected icon.
-   */
-  private updateIconGrid() {
-    this.loadIcons().then((fullyLoaded) => {
-      if (fullyLoaded && this.selectedIconDiv) {
-        const scrollbox = this.iconGrid.parentElement.parentElement;
-        scrollbox.scrollTop = this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2;
-      }
-    });
-  }
-
-  /**
-   * Loads the icons of the currently selected theme and updates the icon grid.
-   *
-   * @returns A promise that resolves when all icons have been loaded or the operation has
-   *   been aborted. The promise resolves to `true` if all icons have been loaded and to
-   *   `false` if the operation has been aborted.
+   * will scroll to the selected icon. The loading happens in batches to avoid blocking
+   * the UI thread for too long. When a previous loadIcons operation is still in progress,
+   * it is aborted.
    */
   private async loadIcons() {
     // Check if there is a previous loadIcons operation in progress. If so, abort it.
     if (this.loadAbortController) {
       this.loadAbortController.abort();
-      this.loadAbortController = null;
     }
 
     // Create a new AbortController for the current operation.
@@ -164,79 +161,116 @@ export class IconPicker extends EventEmitter {
     this.iconGrid.innerHTML = '';
     this.container.classList.add('loading');
 
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
     const theme = IconThemeRegistry.getInstance().getTheme(this.themeSelect.value);
     const icons = await theme.listIcons(this.filterInput.value);
 
-    // Create a new Promise for the current operation. This promise will resolve when all
-    // icons have been loaded or the operation has been aborted.
-    return new Promise<boolean>((resolve) => {
-      // We add the icons in batches to avoid blocking the UI thread for too long.
-      const batchSize = 150;
-      let startIndex = 0;
+    // We add the icons in batches to avoid blocking the UI thread for too long.
+    const batchSize = 150;
+    let startIndex = 0;
 
-      const addBatch = () => {
-        const endIndex = Math.min(startIndex + batchSize, icons.length);
-        const fragment = document.createDocumentFragment();
-        for (let i = startIndex; i < endIndex; i++) {
-          const iconName = icons[i];
-          const iconDiv = theme.createDiv(iconName);
-          iconDiv.setAttribute('data-bs-toggle', 'tooltip');
-          iconDiv.setAttribute('title', iconName);
-          if (iconName === this.selectedIcon) {
-            iconDiv.classList.add('selected');
+    const addBatch = () => {
+      const endIndex = Math.min(startIndex + batchSize, icons.length);
+      const fragment = document.createDocumentFragment();
+      for (let i = startIndex; i < endIndex; i++) {
+        const iconName = icons[i];
 
-            this.selectedIconDiv = iconDiv;
+        const iconButton = document.createElement('div');
+
+        // Add the attributes required for the tooltip.
+        iconButton.setAttribute('data-bs-toggle', 'tooltip');
+        iconButton.setAttribute('title', iconName);
+
+        // The icon-name attribute is used when loading the icon when the button becomes
+        // visible.
+        iconButton.setAttribute('icon-name', iconName);
+
+        if (iconName === this.selectedIcon) {
+          iconButton.classList.add('selected');
+          this.selectedIconDiv = iconButton;
+        }
+
+        fragment.appendChild(iconButton);
+
+        // Initialize the tooltip for the newly created icon.
+        new Tooltip(iconButton, {
+          delay: { show: 500, hide: 0 },
+        });
+
+        // When the user clicks an icon, emit the select-icon event and add the
+        // selected class to the icon.
+        iconButton.addEventListener('click', () => {
+          if (this.selectedIconDiv) {
+            this.selectedIconDiv.classList.remove('selected');
           }
-          fragment.appendChild(iconDiv);
+          iconButton.classList.add('selected');
 
-          // Initialize the tooltip for the newly created icon
-          new Tooltip(iconDiv, {
-            delay: { show: 500, hide: 0 }, // Adjust delay as needed
-          });
+          this.selectedIcon = iconName;
+          this.selectedIconDiv = iconButton;
 
-          // When the user clicks an icon, emit the select-icon event and add the
-          // selected class to the icon.
-          iconDiv.addEventListener('click', () => {
-            if (this.selectedIconDiv) {
-              this.selectedIconDiv.classList.remove('selected');
-            }
-            iconDiv.classList.add('selected');
+          this.emit('select', iconName, this.themeSelect.value);
+        });
 
-            this.selectedIcon = iconName;
-            this.selectedIconDiv = iconDiv;
+        // When the user double-clicks an icon, emit the close event.
+        iconButton.addEventListener('dblclick', () => {
+          this.hide();
+        });
+      }
 
-            this.emit('select', iconName, this.themeSelect.value);
-          });
+      // Before actually modifying the DOM, check if the operation has been aborted.
+      if (abortController.signal.aborted) {
+        return;
+      }
 
-          // When the user double-clicks an icon, emit the close event.
-          iconDiv.addEventListener('dblclick', () => {
-            this.hide();
-          });
+      this.iconGrid.appendChild(fragment);
+
+      startIndex = endIndex;
+
+      // If there are still icons pending, yield to let the UI thread continue a bit and
+      // then add the next batch of icons.
+      if (startIndex < icons.length) {
+        requestAnimationFrame(addBatch);
+      } else {
+        // The loading operation is finished. Clean up and scroll to the selected icon.
+        this.loadAbortController = null;
+        this.container.classList.remove('loading');
+
+        const scrollbox = this.iconGrid.parentElement.parentElement;
+        if (this.selectedIconDiv) {
+          scrollbox.scrollTop =
+            this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2;
         }
 
-        // Before modifying the DOM, check if the operation has been aborted.
-        if (abortController.signal.aborted) {
-          resolve(false);
-          return;
-        }
+        // Create the observer that is used to detect when icons are scrolled into view.
+        // Once an icon is visible, the icon is loaded into the button. This is done to
+        // avoid loading all icons at once.
+        this.observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              const iconButton = entry.target;
+              const iconName = iconButton.attributes.getNamedItem('icon-name').value;
 
-        this.iconGrid.appendChild(fragment);
+              if (entry.isIntersecting) {
+                iconButton.appendChild(theme.createDiv(iconName));
+              } else {
+                iconButton.innerHTML = '';
+              }
+            });
+          },
+          { root: scrollbox, delay: 100 }
+        );
 
-        startIndex = endIndex;
+        // Observe all icons in the grid. We get the icons by querying the grid for all
+        // divs having the icon-name attribute.
+        const icons = this.iconGrid.querySelectorAll('div[icon-name]');
+        icons.forEach((icon) => this.observer.observe(icon));
+      }
+    };
 
-        // If there are still icons pending, yield to let the UI thread continue a bit and
-        // then add the next batch of icons. Else resolve the promise.
-        if (startIndex < icons.length) {
-          requestAnimationFrame(addBatch);
-        } else {
-          this.loadAbortController = null;
-          this.container.classList.remove('loading');
-          resolve(true);
-        }
-      };
-
-      // Start adding the first batch of icons.
-      addBatch();
-    });
+    // Start adding the first batch of icons.
+    addBatch();
   }
 }

--- a/src/renderer/editor/properties/style/icon-picker.scss
+++ b/src/renderer/editor/properties/style/icon-picker.scss
@@ -53,7 +53,8 @@
   grid-template-columns: repeat(auto-fill, minmax(calc(32px + 2vw), 1fr));
   transition: opacity 150ms ease;
 
-  .icon-container {
+  & > div {
+    aspect-ratio: 1 / 1;
     border-radius: var(--bs-border-radius);
     clip-path: none;
 

--- a/src/renderer/editor/properties/templates/icon-picker.hbs
+++ b/src/renderer/editor/properties/templates/icon-picker.hbs
@@ -9,6 +9,9 @@
 // SPDX-License-Identifier: MIT
 }}
 
+<div class="fs-1 kando-font">{{heading}}</div>
+<div class="fs-5 kando-font mb-3">{{{subheading}}}</div>
+
 <div class='d-flex'>
   <input type="text" class="fs-3 kando-font form-control flex-grow-1 me-3" placeholder="Search Icons..." id="kando-properties-icon-filter" />
   <select class="form-select fs-3 kando-font form-control" id="kando-properties-icon-theme-select">
@@ -18,7 +21,7 @@
   </select>
 </div>
 
-<div class='scrollbox mx-2' style="height: 35vh;">
+<div class='scrollbox mx-2' style="height: 30vh;">
   <div class="scrollbox-content">
     <div id="kando-properties-icon-picker-grid" class="justify-content-start"></div>
   </div>

--- a/src/renderer/menu/menu.scss
+++ b/src/renderer/menu/menu.scss
@@ -54,7 +54,8 @@
       .icon-container {
         transition: $menu-transition;
 
-        color: transparent;
+        opacity: 0;
+        color: $text-color;
 
         container-type: size;
         width: 100%;
@@ -92,7 +93,7 @@
       transform: scale(0.9);
 
       & > .icon-container {
-        color: $text-color;
+        opacity: 1;
         font-size: calc($root-size * 0.75);
       }
     }
@@ -130,7 +131,7 @@
       transform: scale(1);
 
       & > .icon-container {
-        color: $text-color;
+        opacity: 1;
         font-size: calc($child-size * 0.75);
       }
     }

--- a/src/renderer/menu/menu.scss
+++ b/src/renderer/menu/menu.scss
@@ -72,6 +72,12 @@
           font-size: 75cqi;
           font-style: normal;
         }
+
+        img {
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
       }
     }
 

--- a/src/renderer/menu/menu.scss
+++ b/src/renderer/menu/menu.scss
@@ -18,7 +18,7 @@
     opacity: 0;
 
     // Subtly scale in / out all items when the menu is shown and hidden.
-    .menu-icon {
+    .icon-container {
       transform: scale(0.8) !important;
     }
 
@@ -39,7 +39,7 @@
 
   // The menu consists of a tree of items. Their relative positions are computed in
   // JavaScript and then applied as inline styles. Each node has an additional div as
-  // child with the class menu-icon. This div is used to display the node's content.
+  // child with the class icon-container. This div is used to display the node's content.
   .menu-node {
     transition: $menu-transition;
     position: absolute;
@@ -51,23 +51,27 @@
       transition: $menu-transition;
       border: 1px solid $border-color;
 
-      .menu-icon {
+      .icon-container {
         transition: $menu-transition;
 
-        font-style: normal;
         color: transparent;
+
+        container-type: size;
+        width: 100%;
+        aspect-ratio: 1 / 1;
 
         // Circle clipping.
         clip-path: circle(45% at 50% 50%);
         white-space: nowrap;
 
-        // Center text.
-        width: 100%;
-        height: 100%;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: calc($grandchild-size * 0.75);
+
+        i {
+          font-size: 75cqi;
+          font-style: normal;
+        }
       }
     }
 
@@ -81,7 +85,7 @@
       box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.5);
       transform: scale(0.9);
 
-      & > .menu-icon {
+      & > .icon-container {
         color: $text-color;
         font-size: calc($root-size * 0.75);
       }
@@ -101,7 +105,7 @@
     &.active:has(> .menu-node.hovered) > .menu-item {
       transform: scale(1);
 
-      & > .menu-icon {
+      & > .icon-container {
         opacity: 0;
       }
     }
@@ -119,7 +123,7 @@
       z-index: 1;
       transform: scale(1);
 
-      & > .menu-icon {
+      & > .icon-container {
         color: $text-color;
         font-size: calc($child-size * 0.75);
       }

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from 'events';
 
 import * as math from '../math';
 import { IShowMenuOptions, IVec2 } from '../../common';
+import { IconThemeRegistry } from '../../common/icon-theme-registry';
 import { IRenderedMenuItem } from './rendered-menu-item';
 import { CenterText } from './center-text';
 import { GestureDetection } from './gesture-detection';
@@ -289,8 +290,8 @@ export class Menu extends EventEmitter {
    * each item, a div element with the class ".menu-node" is created and appended to the
    * given container. In addition to the child menu items, the div element contains a div
    * with the class ".menu-item" which contains the visual representation of the item. The
-   * item's icon is rendered as an <i> element with the class ".menu-icon" as a child of
-   * the ".menu-item" element.
+   * item's icon is rendered as an <i> element with the class ".icon-container" as a child
+   * of the ".menu-item" element.
    *
    * @param item The menu item to create the DOM tree for.
    * @param container The container to append the DOM tree to.
@@ -305,37 +306,18 @@ export class Menu extends EventEmitter {
 
       const nodeDiv = document.createElement('div');
       const menuItem = document.createElement('div');
-      const icon = document.createElement('i');
+      const icon = IconThemeRegistry.getInstance()
+        .getTheme(item.iconTheme)
+        .createDiv(item.icon);
 
       nodeDiv.classList.add('menu-node');
       menuItem.classList.add('menu-item');
-      icon.classList.add('menu-icon');
 
       container.appendChild(nodeDiv);
       nodeDiv.appendChild(menuItem);
       menuItem.appendChild(icon);
 
       item.nodeDiv = nodeDiv;
-
-      switch (item.iconTheme) {
-        case 'material-symbols-rounded':
-          icon.classList.add('material-symbols-rounded');
-          icon.innerText = item.icon;
-          break;
-        case 'emoji':
-          icon.classList.add('emoji-icon');
-          icon.innerText = item.icon;
-          break;
-        case 'simple-icons':
-          icon.classList.add('si');
-          icon.classList.add('si-' + item.icon);
-          break;
-        case 'simple-icons-colored':
-          icon.classList.add('si');
-          icon.classList.add('si--color');
-          icon.classList.add('si-' + item.icon);
-          break;
-      }
 
       if (item.children) {
         item.connectorDiv = document.createElement('div');

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -70,6 +70,11 @@ contextBridge.exposeInMainWorld('api', {
     return ipcRenderer.invoke('get-backend-info');
   },
 
+  /** This will return the path to the user's icon theme directory in the config directory. */
+  getUserIconThemeDirectory: function () {
+    return ipcRenderer.invoke('get-user-icon-theme-directory');
+  },
+
   /**
    * This will return all subdirectories of the icon-themes directory in the config
    * directory.

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -70,6 +70,23 @@ contextBridge.exposeInMainWorld('api', {
     return ipcRenderer.invoke('get-backend-info');
   },
 
+  /**
+   * This will return all subdirectories of the icon-themes directory in the config
+   * directory.
+   */
+  getUserIconThemes: function () {
+    return ipcRenderer.invoke('get-user-icon-themes');
+  },
+
+  /**
+   * This will return all files in the given icon theme directory.
+   *
+   * @param iconTheme The icon theme to list.
+   */
+  listUserIcons: function (iconTheme: string) {
+    return ipcRenderer.invoke('list-user-icons', iconTheme);
+  },
+
   /** This will show the web developer tools. */
   showDevTools: function () {
     ipcRenderer.send('show-dev-tools');

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -133,6 +133,16 @@ contextBridge.exposeInMainWorld('api', {
   },
 
   /**
+   * This will be called by the host process when the editor should be hidden. This
+   * happens for instance when the user clicks on an external link.
+   *
+   * @param callback This callback will be called when the editor should be hidden.
+   */
+  hideEditor: function (callback: () => void) {
+    ipcRenderer.on('hide-editor', callback);
+  },
+
+  /**
    * This will be called by the host process when the user should be shown a button to
    * update the app.
    *


### PR DESCRIPTION
This resolves #383.

To add your own icons to Kando, follow these steps:
1. Create a new `icon-themes` directory in Kando's configuration directory if it does not yet exist. Depending on your OS, this will be the following locations:
    * <img height="14" width="26" src="https://cdn.simpleicons.org/windows" /> Windows: `%appdata%\kando\icon-themes`
    * <img height="14" width="26" src="https://cdn.simpleicons.org/apple" /> macOS: `~/Library/Application Support/kando/icon-themes`
    * <img height="14" width="26" src="https://cdn.simpleicons.org/linux/black" /> Linux: `~/.config/kando/icon-themes`
2. Create a new directory for your icon theme in the `icon-themes` directory. You can give it any name you like.
3. Add your icons to the new directory. The icons can be in various formats, but we recommend using SVG files.
4. **Restart Kando.** Icon themes are only loaded when Kando starts.
5. Select your icon theme in the icon-theme dropdown in the icon picker in Kando's menu editor.