### PR TITLE
Implement keyboard navigation

### DIFF
--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -173,8 +173,9 @@ export class Menu extends EventEmitter {
     // In order to keep track of any pressed key for the turbo mode, we listen to keydown
     // and keyup events.
     document.addEventListener('keydown', (event) => {
+      const anyModifierPressed = event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
       const menuKeys = '0123456789abcdefghijklmnopqrstuvwxyz';
-      if (menuKeys.includes(event.key)) {
+      if (!anyModifierPressed && menuKeys.includes(event.key)) {
         const index = menuKeys.indexOf(event.key);
         if (index === 0) {
           if (this.selectionChain.length > 1) {

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -173,7 +173,25 @@ export class Menu extends EventEmitter {
     // In order to keep track of any pressed key for the turbo mode, we listen to keydown
     // and keyup events.
     document.addEventListener('keydown', (event) => {
-      if (event.key !== 'Escape') {
+      const menuKeys = '0123456789abcdefghijklmnopqrstuvwxyz';
+      if (menuKeys.includes(event.key)) {
+        const index = menuKeys.indexOf(event.key);
+        if (index === 0) {
+          if (this.selectionChain.length > 1) {
+            this.selectItem(this.selectionChain[this.selectionChain.length - 2]);
+          } else {
+            this.emit('cancel');
+          }
+        } else {
+          const currentItem = this.selectionChain[this.selectionChain.length - 1];
+          if (currentItem.children) {
+            const child = currentItem.children[index - 1];
+            if (child) {
+              this.selectItem(child);
+            }
+          }
+        }
+      } else if (event.key !== 'Escape') {
         this.input.onKeyDownEvent();
       }
     });

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -173,7 +173,8 @@ export class Menu extends EventEmitter {
     // In order to keep track of any pressed key for the turbo mode, we listen to keydown
     // and keyup events.
     document.addEventListener('keydown', (event) => {
-      const anyModifierPressed = event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
+      const anyModifierPressed =
+        event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
       const menuKeys = '0123456789abcdefghijklmnopqrstuvwxyz';
       if (!anyModifierPressed && menuKeys.includes(event.key)) {
         const index = menuKeys.indexOf(event.key);


### PR DESCRIPTION
The principle is simple. `0123456789abcdefghijklmnopqrstuvwxyz` is used as an index to select a menu entry. In <https://github.com/Frenzie/nimbler> I also used uppercase should lowercase run out, but I don't believe that's necessary here.

0 closes the menu at the root or goes back one level when deeper down.

The remainder is automatically assigned a clockwise number, starting from the topmost item.

References #291. To close it, presumably some display is desired as well.

<hr>

![screenshot-kando-keyboard](https://github.com/user-attachments/assets/9102eae1-f618-4e5a-a874-da59e8a9b0d3)
