### PR TITLE
support info-placeholders in URI item actions

### DIFF
--- a/src/common/item-types/uri-item-action.ts
+++ b/src/common/item-types/uri-item-action.ts
@@ -12,7 +12,7 @@ import { IMenuItem } from '../index';
 import { IItemAction } from '../item-action-registry';
 import { DeepReadonly } from '../../main/settings';
 import { IItemData } from './uri-item-type';
-import { WMInfo, Backend } from '../../main/backends/backend'
+import { WMInfo, Backend } from '../../main/backends/backend';
 import { shell } from 'electron';
 
 /**
@@ -30,19 +30,19 @@ export class URIItemAction implements IItemAction {
   }
 
   /**
- * Replaces placeholders in the URI string with actual values.
- *
- * @param uri The URI string.
- * @param wmInfo Information about the window manager state when the menu was opened.
- * @returns The URI string with placeholders replaced.
- */
-private replacePlaceholders(uri: string, wmInfo: WMInfo): string {
-  return uri
-    .replace(/\{{app_name}}/g, wmInfo.appName)
-    .replace(/\{{window_name}}/g, wmInfo.windowName)
-    .replace(/\{{pointer_x}}/g, wmInfo.pointerX.toString())
-    .replace(/\{{pointer_y}}/g, wmInfo.pointerY.toString());
-}
+   * Replaces placeholders in the URI string with actual values.
+   *
+   * @param uri The URI string.
+   * @param wmInfo Information about the window manager state when the menu was opened.
+   * @returns The URI string with placeholders replaced.
+   */
+  private replacePlaceholders(uri: string, wmInfo: WMInfo): string {
+    return uri
+      .replace(/\{{app_name}}/g, wmInfo.appName)
+      .replace(/\{{window_name}}/g, wmInfo.windowName)
+      .replace(/\{{pointer_x}}/g, wmInfo.pointerX.toString())
+      .replace(/\{{pointer_y}}/g, wmInfo.pointerY.toString());
+  }
 
   /**
    * Opens the URI with the default application.
@@ -51,9 +51,9 @@ private replacePlaceholders(uri: string, wmInfo: WMInfo): string {
    * @param wmInfo Information about the window manager state when the menu was opened.
    * @returns A promise which resolves when the URI has been successfully opened.
    */
-  async execute(item: DeepReadonly<IMenuItem>, backend:Backend, wmInfo: WMInfo) {
-    let uri= (item.data as IItemData).uri
-    uri = this.replacePlaceholders(uri, wmInfo)
+  async execute(item: DeepReadonly<IMenuItem>, backend: Backend, wmInfo: WMInfo) {
+    let uri = (item.data as IItemData).uri;
+    uri = this.replacePlaceholders(uri, wmInfo);
     return shell.openExternal(uri);
   }
 }

--- a/src/common/item-types/uri-item-action.ts
+++ b/src/common/item-types/uri-item-action.ts
@@ -12,7 +12,7 @@ import { IMenuItem } from '../index';
 import { IItemAction } from '../item-action-registry';
 import { DeepReadonly } from '../../main/settings';
 import { IItemData } from './uri-item-type';
-
+import { WMInfo, Backend } from '../../main/backends/backend'
 import { shell } from 'electron';
 
 /**
@@ -30,12 +30,30 @@ export class URIItemAction implements IItemAction {
   }
 
   /**
+ * Replaces placeholders in the URI string with actual values.
+ *
+ * @param uri The URI string.
+ * @param wmInfo Information about the window manager state when the menu was opened.
+ * @returns The URI string with placeholders replaced.
+ */
+private replacePlaceholders(uri: string, wmInfo: WMInfo): string {
+  return uri
+    .replace(/\{{app_name}}/g, wmInfo.appName)
+    .replace(/\{{window_name}}/g, wmInfo.windowName)
+    .replace(/\{{pointer_x}}/g, wmInfo.pointerX.toString())
+    .replace(/\{{pointer_y}}/g, wmInfo.pointerY.toString());
+}
+
+  /**
    * Opens the URI with the default application.
    *
    * @param item The item for which the action should be executed.
+   * @param wmInfo Information about the window manager state when the menu was opened.
    * @returns A promise which resolves when the URI has been successfully opened.
    */
-  async execute(item: DeepReadonly<IMenuItem>) {
-    return shell.openExternal((item.data as IItemData).uri);
+  async execute(item: DeepReadonly<IMenuItem>, backend:Backend, wmInfo: WMInfo) {
+    let uri= (item.data as IItemData).uri
+    uri = this.replacePlaceholders(uri, wmInfo)
+    return shell.openExternal(uri);
   }
 }

--- a/src/common/item-types/uri-item-config.ts
+++ b/src/common/item-types/uri-item-config.ts
@@ -21,6 +21,9 @@ export class URIItemConfig implements IItemConfig {
       'You can use the URI item type to open a website using the http:// protocol.',
       'You can use the URI item type to open a file or folder using the file:// protocol.',
       'You can use the URI item type to open a mailto: link.',
+      'Use {{app_name}} to insert the name of the application which was focused when you opened the menu.',
+      'Use {{window_name}} to insert the name of the window which was focused when you opened the menu.',
+      'Use {{pointer_x}} and {{pointer_y}} to insert the pointer position where the menu was opened.',
     ];
 
     return tips[Math.floor(Math.random() * tips.length)];


### PR DESCRIPTION
Support info placeholders in URI item actions. For the issue [#571](https://github.com/kando-menu/kando/issues/571).