### PR TITLE
🐛 Fix Cinnamon/X11 window type to display over full-screen apps

### DIFF
--- a/src/main/backends/index.ts
+++ b/src/main/backends/index.ts
@@ -58,6 +58,12 @@ export function getBackend(): Backend | null {
       return new HyprBackend();
     }
 
+    if (desktop === 'X-Cinnamon' && session === 'x11') {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const { CinnamonBackend } = require('./linux/cinnamon/x11/backend');
+      return new CinnamonBackend();
+    }
+
     if (session === 'x11') {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const { X11Backend } = require('./linux/x11/backend');

--- a/src/main/backends/linux/cinnamon/x11/backend.ts
+++ b/src/main/backends/linux/cinnamon/x11/backend.ts
@@ -1,0 +1,24 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { X11Backend } from '../../x11/backend';
+
+/** This backend is used on Cinnamon with X11. */
+export class CinnamonBackend extends X11Backend {
+    /**
+     * On Cinnamon, the 'normal' window type is used. The 'dock' window type makes the window
+     * not show on top of other applications' full-screen windows.
+     */
+    public getBackendInfo() {
+        const info = super.getBackendInfo();
+        info.windowType = 'normal';
+        return info;
+    }
+}

--- a/src/main/backends/linux/cinnamon/x11/backend.ts
+++ b/src/main/backends/linux/cinnamon/x11/backend.ts
@@ -12,13 +12,13 @@ import { X11Backend } from '../../x11/backend';
 
 /** This backend is used on Cinnamon with X11. */
 export class CinnamonBackend extends X11Backend {
-    /**
-     * On Cinnamon, the 'normal' window type is used. The 'dock' window type makes the window
-     * not show on top of other applications' full-screen windows.
-     */
-    public getBackendInfo() {
-        const info = super.getBackendInfo();
-        info.windowType = 'normal';
-        return info;
-    }
+  /**
+   * On Cinnamon, the 'normal' window type is used. The 'dock' window type makes the
+   * window not show on top of other applications' full-screen windows.
+   */
+  public getBackendInfo() {
+    const info = super.getBackendInfo();
+    info.windowType = 'normal';
+    return info;
+  }
 }


### PR DESCRIPTION
# Problem Description

In the Cinnamon X11 environment, the Kando menu does not appear over full-screen applications because the window type is set to `'dock'`, which doesn't overlay full-screen windows.

# Solution

- Changed the window type to `'normal'` to ensure the menu displays over full-screen apps.
- **Files Added**:
  - `src/main/backends/linux/cinnamon/x11/backend.ts`: Added to handle the specific window type setting for Cinnamon X11.
- **Files Modified**:
  - `src/main/backends/index.ts`: Integrated the new backend into the main backend index.

# Known Issues

- **Multiple Monitors**: On systems with multiple monitors, when the cursor is on the primary display, the Kando menu appears on a different display. Further investigation is required to fix this behavior.

# Testing Performed

- Tested with full-screen applications (Firefox, Xournal++). The menu now appears as expected.
- Acknowledged the issue on multi-monitor setups.

# Additional Notes

- This change is specific to the Cinnamon X11 backend and does not affect other desktop environments.
- Related to discussion in issue #620