### PR TITLE
Load icons from installation directory.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,11 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 **Release Date:** TBD
 
+#### :tada: Added
+
+- Icon themes are now also loaded from `resources/app/.webpack/renderer/assets/icon-themes/` in the installation directory. This can be interesting if you are packaging icon themes using a package manager. However, as an end user, you should not put your icon themes there, as they might be overwritten during an update.
+- Support for symbolic links in the `icon-themes` directory. You can now create a symbolic link to an icon theme in the `icon-themes` directory and Kando will load the icons from the linked directory.
+
 #### :wrench: Changed
 
 - Menu themes are now also loaded from symbolic-link subdirectories in the `menu-themes` directories.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -40,6 +40,9 @@ To add your own icons to Kando, follow these steps:
 4. **Restart Kando.** Icon themes are only loaded when Kando starts.
 5. Select your icon theme in the icon-theme dropdown in the icon picker in Kando's menu editor.
 
+> [!CAUTION]
+> Kando will also load icon themes from `resources/app/.webpack/renderer/assets/icon-themes/` in the installation directory. This can be interesting if you are packaging icon themes using a package manager. However, as an end user, you should not put your icon themes there, as they might be overwritten during an update.
+
 ### Some Tips for Creating Icon Themes
 
 * You can organize your icons in subdirectories. Kando will load them recursively. The directory will be part of the icon's name and therefore you can use the search bar to filter by directory.

--- a/docs/menu-themes.md
+++ b/docs/menu-themes.md
@@ -29,8 +29,8 @@ First, Kando will look for menu-theme directories in your home directory:
 * <img height="14" width="26" src="https://cdn.simpleicons.org/apple" /> macOS: `~/Library/Application Support/kando/menu-themes/`
 * <img height="14" width="26" src="https://cdn.simpleicons.org/linux/black" /> Linux: `~/.config/kando/menu-themes/`
 
-Next, Kando will look for menu-theme directories in the installation directory.
-For this, look for the `resources/app/.webpack/renderer/assets/menu-themes/` directory in the installation directory.
+> [!CAUTION]
+> Kando will also attempt to load menu themes from `resources/app/.webpack/renderer/assets/menu-themes/` in the installation directory. This can be interesting if you are packaging themes using a package manager. However, as an end user, you should not put your themes there, as they might be overwritten during an update.
 
 If you are running Kando from the source code via `npm start`, it will look for themes in the `assets/menu-themes/` directory.
 

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -16,6 +16,7 @@ import {
   IMenuSettings,
   IShowMenuOptions,
   IShowEditorOptions,
+  IIconThemesInfo,
 } from '../common';
 
 // Declare the API to the host process. See preload.ts for more information on the exposed
@@ -46,9 +47,7 @@ declare global {
       getCurrentMenuThemeColors: () => Promise<Record<string, string>>;
       getIsDarkMode: () => Promise<boolean>;
       darkModeChanged: (callback: (darkMode: boolean) => void) => void;
-      getUserIconThemeDirectory: () => Promise<string>;
-      getUserIconThemes: () => Promise<Array<string>>;
-      listUserIcons: (string: iconTheme) => Promise<Array<string>>;
+      getIconThemes: () => Promise<IIconThemesInfo>;
       showDevTools: () => void;
       reloadMenuTheme: () => void;
       movePointer: (dist: IVec2) => void;

--- a/src/common/icon-theme-registry.ts
+++ b/src/common/icon-theme-registry.ts
@@ -12,7 +12,7 @@ import { SimpleIconsTheme } from './icon-themes/simple-icons-theme';
 import { SimpleIconsColoredTheme } from './icon-themes/simple-icons-colored-theme';
 import { MaterialSymbolsTheme } from './icon-themes/material-symbols-theme';
 import { EmojiTheme } from './icon-themes/emoji-theme';
-import { UserIconTheme } from './icon-themes/user-icon-theme';
+import { FileIconTheme } from './icon-themes/file-icon-theme';
 import { FallbackTheme } from './icon-themes/fallback-theme';
 
 /**
@@ -72,13 +72,10 @@ export class IconThemeRegistry {
     this.iconThemes.set('emoji', new EmojiTheme());
 
     // Add an icon theme for all icon themes in the user's icon theme directory.
-    Promise.all([
-      window.api.getUserIconThemeDirectory(),
-      window.api.getUserIconThemes(),
-    ]).then(([directory, themes]) => {
-      this._userIconThemeDirectory = directory;
-      for (const theme of themes) {
-        this.iconThemes.set(theme, new UserIconTheme(directory, theme));
+    window.api.getIconThemes().then((info) => {
+      this._userIconThemeDirectory = info.userIconDirectory;
+      for (const theme of info.fileIconThemes) {
+        this.iconThemes.set(theme.name, new FileIconTheme(theme));
       }
     });
   }

--- a/src/common/icon-themes/file-icon-theme.ts
+++ b/src/common/icon-themes/file-icon-theme.ts
@@ -11,38 +11,26 @@
 import { matchSorter } from 'match-sorter';
 
 import { IIconTheme } from '../icon-theme-registry';
+import { IFileIconThemeDescription } from '..';
 
 /**
- * This class is used for custom icon themes loaded from the icon-themes subdirectory of
- * Kando's config directory.
+ * This class is used for custom icon themes loaded from a icon-themes directory on the
+ * user's file system.
  */
-export class UserIconTheme implements IIconTheme {
-  /** This array contains all available icon names. It is initialized in the constructor. */
-  private iconNames: Array<string> = [];
-
+export class FileIconTheme implements IIconTheme {
   /**
-   * Creates a new UserIconTheme.
+   * Creates a new FileIconTheme.
    *
-   * @param directory This is the path to the icon-themes directory in Kando's config
-   *   directory.
-   * @param subdirectory This is the name of the icon theme's subdirectory in the
-   *   icon-themes directory.
+   * @param description The description of the icon theme.
    */
-  constructor(
-    private directory: string,
-    private subdirectory: string
-  ) {
-    window.api.listUserIcons(this.subdirectory).then((icons: Array<string>) => {
-      this.iconNames = icons;
-    });
-  }
+  constructor(private description: IFileIconThemeDescription) {}
 
   /**
    * The name of the icon corresponds to the name of the directory in the icon-themes
    * subdirectory of Kando's config directory.
    */
   get name() {
-    return this.subdirectory;
+    return this.description.name;
   }
 
   /**
@@ -52,7 +40,7 @@ export class UserIconTheme implements IIconTheme {
    * @returns An array of icon names that match the search term.
    */
   public async listIcons(searchTerm: string) {
-    return matchSorter(this.iconNames, searchTerm);
+    return matchSorter(this.description.icons, searchTerm);
   }
 
   /**
@@ -66,7 +54,7 @@ export class UserIconTheme implements IIconTheme {
     containerDiv.classList.add('icon-container');
 
     const iconDiv = document.createElement('img');
-    iconDiv.src = `file://${this.directory}/${this.subdirectory}/${icon}`;
+    iconDiv.src = `file://${this.description.directory}/${icon}`;
     iconDiv.draggable = false;
 
     containerDiv.appendChild(iconDiv);

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -111,6 +111,40 @@ export interface IMenuThemeDescription {
   }[];
 }
 
+/** This interface describes a icon theme consisting of a collection of icon files. */
+export interface IFileIconThemeDescription {
+  /**
+   * The ID of the theme. This is used to identify the theme in the settings file. It is
+   * also the directory name of the icon theme.
+   */
+  name: string;
+
+  /**
+   * The absolute path to the directory where the theme is stored, including the name as
+   * the last part of the path.
+   */
+  directory: string;
+
+  /**
+   * A list of all available icons in this theme. These are the filenames of the icons
+   * relative to the theme directory. In case of nested directories, the filenames can
+   * actually be paths.
+   */
+  icons: string[];
+}
+
+/**
+ * This interface is used to pass information about all available icon themes to the
+ * renderer process.
+ */
+export interface IIconThemesInfo {
+  /** The absolute path to the directory where the user may store custom icon themes. */
+  userIconDirectory: string;
+
+  /** All available file icon themes. */
+  fileIconThemes: IFileIconThemeDescription[];
+}
+
 /**
  * This interface is used to describe an element of a key sequence. It contains the DOM
  * name of the key, a boolean indicating whether the key is pressed or released and a

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -37,9 +37,6 @@ Promise.all([
     fallbackLng: locales.fallbackLng,
   });
 
-  console.log('Current locale:');
-  console.log(locales.current);
-
   Object.keys(locales.data).forEach((key) => {
     i18next.addResourceBundle(
       key,

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -109,26 +109,9 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('dark-mode-changed', (e, darkMode) => callback(darkMode));
   },
 
-  /** This will return the path to the user's icon theme directory in the config directory. */
-  getUserIconThemeDirectory: function () {
-    return ipcRenderer.invoke('get-user-icon-theme-directory');
-  },
-
-  /**
-   * This will return all subdirectories of the icon-themes directory in the config
-   * directory.
-   */
-  getUserIconThemes: function () {
-    return ipcRenderer.invoke('get-user-icon-themes');
-  },
-
-  /**
-   * This will return all files in the given icon theme directory.
-   *
-   * @param iconTheme The icon theme to list.
-   */
-  listUserIcons: function (iconTheme: string) {
-    return ipcRenderer.invoke('list-user-icons', iconTheme);
+  /** This will return a IIconThemesInfo describing all available icon themes. */
+  getIconThemes: function () {
+    return ipcRenderer.invoke('get-icon-themes');
   },
 
   /** This will show the web developer tools. */


### PR DESCRIPTION
This resolves #614.

Icon themes are now also loaded from `resources/app/.webpack/renderer/assets/icon-themes/` in the installation directory. This can be interesting if you are packaging icon themes using a package manager. However, as an end user, you should not put your icon themes there, as they might be overwritten during an update.

You can now create a symbolic link to an icon theme in the `icon-themes` directory and Kando will load the icons from the linked directory.