### PR TITLE
Add support for base64 icons

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### :tada: Added
 
+- **Support for base64 icons!** This allows you to directly embed base64 encoded images. This will be especially helpful for menus which are dynamically generated via some sort of API in the future. Use `"base64"` as the icon theme and provide the base64 encoded image as the `"icon"`. This will be a string starting with something like `"data:image/svg+xml;base64, ..."`. This even supports animated gifs!
 - Icon themes are now also loaded from `resources/app/.webpack/renderer/assets/icon-themes/` in the installation directory. This can be interesting if you are packaging icon themes using a package manager. However, as an end user, you should not put your icon themes there, as they might be overwritten during an update.
 - Support for symbolic links in the `icon-themes` directory. You can now create a symbolic link to an icon theme in the `icon-themes` directory and Kando will load the icons from the linked directory.
 

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -97,8 +97,8 @@ Each menu item is a JSON object with the following properties:
 Property | Default Value | Description
 -------- | ------------- | -----------
 `name` | `"undefined"` | The name of the menu item. This is shown in the center of the menu when the item is hovered. The name of the root item defines the name of the menu.
-`iconTheme` | `""` | This can either be one of the built-in icon themes (`"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, or `"emoji"`) or a subdirectory of the `icon-themes` subdirectory in Kando's config directory. The built-in icon themes use icons from [Google's Material Symbols](https://fonts.google.com/icons) or [Simple Icons](https://simpleicons.org/) respectively.
-`icon` | `""` | The name of the icon from the given icon theme or an emoji like `"🚀"`.
+`iconTheme` | `""` | This can either be one of the built-in icon themes (`"material-symbols-rounded"`, `"simple-icons"`, `"simple-icons-colored"`, `"base64"`, or `"emoji"`) or a subdirectory of the `icon-themes` subdirectory in Kando's config directory. The built-in icon themes use icons from [Google's Material Symbols](https://fonts.google.com/icons) or [Simple Icons](https://simpleicons.org/) respectively.
+`icon` | `""` | The name of the icon from the given icon theme, an emoji like `"🚀"` (if the `iconTheme` is `"emoji"`), or a base64-encode image like `"data:image/gif;base64,..."` (if the icon theme is `"base64"`).
 `angle` | _auto_ | If given, this defines the angle of the menu item in degrees. If this is not given, the angle is calculated automatically. 0° means that the item is at the top of the menu, 90° means that the item is on the right side of the menu, and so on. All sibling items are evenly distributed around the items with given angles.
 `type` | `"submenu"` | The type of the menu item. There are several types available. See below for details.
 `data` | `{}` | Depending on the type of the item, this can contain additional data. See below for details.

--- a/src/renderer/editor/editor.scss
+++ b/src/renderer/editor/editor.scss
@@ -37,6 +37,7 @@ $rfs-breakpoint: 1400px;
 // The widgets used to configure the icon-themes are currently located in the icon-themes
 // directory. They are only used in the editor and not by the menu itself.
 @import '../icon-themes/icon-pickers/style/icon-list-picker.scss';
+@import '../icon-themes/icon-pickers/style/base64-picker.scss';
 
 // Handle pointer events -----------------------------------------------------------------
 

--- a/src/renderer/editor/editor.scss
+++ b/src/renderer/editor/editor.scss
@@ -34,6 +34,10 @@ $rfs-breakpoint: 1400px;
 @import './preview/style';
 @import './properties/style';
 
+// The widgets used to configure the icon-themes are currently located in the icon-themes
+// directory. They are only used in the editor and not by the menu itself.
+@import '../icon-themes/icon-pickers/style/icon-list-picker.scss';
+
 // Handle pointer events -----------------------------------------------------------------
 
 // As the editor UI elements are always drawn on top of the actual pie menu, we have to

--- a/src/renderer/editor/preview/preview.ts
+++ b/src/renderer/editor/preview/preview.ts
@@ -16,7 +16,7 @@ import { IEditorMenuItem } from '../common/editor-menu-item';
 import { PreviewDraggable } from './preview-draggable';
 import { PreviewDropTarget } from './preview-drop-target';
 import { IVec2, IMenu } from '../../../common';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { DnDManager } from '../common/dnd-manager';
 
 /**
@@ -162,9 +162,10 @@ export class Preview extends EventEmitter {
     const icon = this.activeItem.div.querySelector('.icon-container');
     icon.remove();
     this.activeItem.div.prepend(
-      IconThemeRegistry.getInstance()
-        .getTheme(this.activeItem.iconTheme)
-        .createDiv(this.activeItem.icon)
+      IconThemeRegistry.getInstance().createIcon(
+        this.activeItem.iconTheme,
+        this.activeItem.icon
+      )
     );
   }
 
@@ -387,9 +388,10 @@ export class Preview extends EventEmitter {
       this.backlink = document.createElement('div');
       this.backlink.classList.add('kando-menu-preview-backlink');
       this.backlink.appendChild(
-        IconThemeRegistry.getInstance()
-          .getTheme('material-symbols-rounded')
-          .createDiv('arrow_back')
+        IconThemeRegistry.getInstance().createIcon(
+          'material-symbols-rounded',
+          'arrow_back'
+        )
       );
       container.appendChild(this.backlink);
 

--- a/src/renderer/editor/preview/utils.ts
+++ b/src/renderer/editor/preview/utils.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import * as math from '../../math';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { IEditorMenuItem } from '../common/editor-menu-item';
 
 /**
@@ -172,9 +172,7 @@ export function computeItemAnglesWithDropIndex(
 export function createCenterDiv(item: IEditorMenuItem) {
   const div = document.createElement('div');
   div.classList.add('kando-menu-preview-center');
-  div.appendChild(
-    IconThemeRegistry.getInstance().getTheme(item.iconTheme).createDiv(item.icon)
-  );
+  div.appendChild(IconThemeRegistry.getInstance().createIcon(item.iconTheme, item.icon));
   return div;
 }
 
@@ -189,9 +187,7 @@ export function createChildDiv(item: IEditorMenuItem) {
   div.classList.add('kando-menu-preview-child');
 
   // Add the icon of the child.
-  div.appendChild(
-    IconThemeRegistry.getInstance().getTheme(item.iconTheme).createDiv(item.icon)
-  );
+  div.appendChild(IconThemeRegistry.getInstance().createIcon(item.iconTheme, item.icon));
 
   // If the child can have children, we add container for the grandchildren. The actual
   // grandchildren divs are added on demand as their number may change if items are
@@ -237,9 +233,10 @@ export function createLockDiv(
     div.classList.add('locked');
   }
 
-  const icon = IconThemeRegistry.getInstance()
-    .getTheme('material-symbols-rounded')
-    .createDiv(initiallyLocked ? 'lock' : 'lock_open');
+  const icon = IconThemeRegistry.getInstance().createIcon(
+    'material-symbols-rounded',
+    initiallyLocked ? 'lock' : 'lock_open'
+  );
   div.appendChild(icon);
 
   div.addEventListener('pointerdown', (e) => {

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -10,25 +10,15 @@
 
 import i18next from 'i18next';
 import { EventEmitter } from 'events';
-import { Tooltip } from 'bootstrap';
 
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
-
-// Extend the IntersectionObserverInit interface to allow for a delay option. This delay
-// was introduced in IntersectionObserver v2 and is for some reason not yet part of the
-// TypeScript definitions.
-declare global {
-  interface IntersectionObserverInit {
-    delay?: number;
-  }
-}
+import { IconThemeRegistry, IIconPicker } from '../../icon-themes/icon-theme-registry';
 
 /**
  * This class is responsible for displaying the icon picker of the menu editor. It emits
- * events when the user chooses a new icon. In fact, whenever an icon is clicked at, the
- * `select-icon` event is emitted. Clicking the Done button will only close the icon
- * picker. The cancel button will also emit the close event, but right before the 'close'
- * event a 'select' event is emitted with the original icon and theme.
+ * events when the user chooses a new icon. Whenever an icon is clicked at, the `select`
+ * event is emitted. Clicking the Done button will only close the icon picker. The cancel
+ * button will also emit the close event, but right before the 'close' event a 'select'
+ * event is emitted with the original icon and theme.
  *
  * @fires hide - When the user closes the icon picker via one of the two buttons.
  * @fires select - When the user selected an icon. The event contains the icon and the
@@ -38,30 +28,14 @@ export class IconPicker extends EventEmitter {
   /** The container to which the icon picker is appended. */
   private container: HTMLElement = null;
 
-  /** The input field for filtering icons. */
-  private filterInput: HTMLInputElement = null;
+  /** This contains the actual icon picker. */
+  private pickerContainer: HTMLElement = null;
+
+  /** The icon picker implementation depends on the selected theme. */
+  private picker: IIconPicker = null;
 
   /** The select field for choosing the icon theme. */
   private themeSelect: HTMLSelectElement = null;
-
-  /** The div containing the grid of icons. */
-  private iconGrid: HTMLElement = null;
-
-  /** The icon that is currently selected. */
-  private selectedIcon: string = null;
-  private selectedIconDiv: HTMLElement = null;
-
-  /** When a new loadIcons operation is started, the previous one is aborted. */
-  private loadAbortController: AbortController = null;
-
-  /** The observer that is used to detect when icons are scrolled into view. */
-  private observer: IntersectionObserver = null;
-
-  /**
-   * The tooltips of the icons in the grid. We need to keep track of them to remove them
-   * when the icon grid is reloaded.
-   */
-  private tooltips: Tooltip[] = [];
 
   /** The icon and theme that were selected when the icon picker was opened. */
   private initialTheme: string = null;
@@ -88,7 +62,6 @@ export class IconPicker extends EventEmitter {
           path: IconThemeRegistry.getInstance().userIconThemeDirectory,
           link: 'href="https://github.com/kando-menu/kando/blob/main/docs/configuring.md#adding-custom-icon-themes-sparkles" target="_blank"',
         }),
-        placeholder: i18next.t('properties.icon-picker.placeholder'),
         cancel: i18next.t('properties.common.cancel'),
         done: i18next.t('properties.common.done'),
       },
@@ -103,19 +76,14 @@ export class IconPicker extends EventEmitter {
     container.classList.value = 'd-flex flex-column justify-content-center hidden';
     container.innerHTML = template(data);
 
-    // Store a reference to the icon grid, the filter input and the theme select field.
-    this.iconGrid = container.querySelector('#kando-properties-icon-picker-grid');
-
-    this.filterInput = container.querySelector(
-      '#kando-properties-icon-filter'
-    ) as HTMLInputElement;
+    // Store a reference to the icon picker container and the theme select field.
+    this.pickerContainer = container.querySelector('#kando-properties-icon-picker');
 
     this.themeSelect = container.querySelector(
       '#kando-properties-icon-theme-select'
     ) as HTMLSelectElement;
 
-    this.filterInput.addEventListener('input', () => this.loadIcons());
-    this.themeSelect.addEventListener('change', () => this.loadIcons());
+    this.themeSelect.addEventListener('change', () => this.initPicker());
 
     // Close the icon picker when the user clicks the close button.
     const okButton = container.querySelector('#kando-properties-icon-picker-ok');
@@ -140,19 +108,17 @@ export class IconPicker extends EventEmitter {
   public show(icon: string, theme: string) {
     this.container.classList.remove('hidden');
     this.initialIcon = icon;
-    this.selectedIcon = icon;
     this.initialTheme = theme;
 
     this.themeSelect.value = theme;
 
-    this.loadIcons();
+    this.initPicker();
   }
 
   /** Hides the icon picker. */
   public hide() {
-    if (this.loadAbortController) {
-      this.loadAbortController.abort();
-      this.loadAbortController = null;
+    if (this.picker) {
+      this.picker.deinit();
     }
 
     this.container.classList.add('hidden');
@@ -160,141 +126,21 @@ export class IconPicker extends EventEmitter {
     this.emit('hide');
   }
 
-  /**
-   * Reloads the icons of the currently selected theme and updates the icon grid. The grid
-   * will scroll to the selected icon. The loading happens in batches to avoid blocking
-   * the UI thread for too long. When a previous loadIcons operation is still in progress,
-   * it is aborted.
-   */
-  private async loadIcons() {
-    // Check if there is a previous loadIcons operation in progress. If so, abort it.
-    if (this.loadAbortController) {
-      this.loadAbortController.abort();
+  /** Initializes the icon picker. */
+  private initPicker() {
+    const theme = this.themeSelect.value;
+
+    if (this.picker) {
+      this.picker.deinit();
     }
 
-    // Create a new AbortController for the current operation.
-    const abortController = new AbortController();
-    this.loadAbortController = abortController;
+    this.picker = IconThemeRegistry.getInstance().createIconPicker(theme);
 
-    // Clear existing icons.
-    this.iconGrid.innerHTML = '';
-    this.container.classList.add('loading');
+    this.pickerContainer.innerHTML = '';
+    this.pickerContainer.appendChild(this.picker.getElement());
 
-    if (this.observer) {
-      this.observer.disconnect();
-    }
-
-    // Clear the tooltips.
-    this.tooltips.forEach((tooltip) => tooltip.dispose());
-    this.tooltips = [];
-
-    const theme = IconThemeRegistry.getInstance().getTheme(this.themeSelect.value);
-    const icons = await theme.listIcons(this.filterInput.value);
-
-    // We add the icons in batches to avoid blocking the UI thread for too long.
-    const batchSize = 150;
-    let startIndex = 0;
-
-    const addBatch = () => {
-      const endIndex = Math.min(startIndex + batchSize, icons.length);
-      const fragment = document.createDocumentFragment();
-      for (let i = startIndex; i < endIndex; i++) {
-        const iconName = icons[i];
-
-        const iconButton = document.createElement('div');
-
-        // Add the attributes required for the tooltip.
-        iconButton.setAttribute('data-bs-toggle', 'tooltip');
-        iconButton.setAttribute('title', iconName);
-
-        // The icon-name attribute is used when loading the icon when the button becomes
-        // visible.
-        iconButton.setAttribute('icon-name', iconName);
-
-        if (iconName === this.selectedIcon) {
-          iconButton.classList.add('selected');
-          this.selectedIconDiv = iconButton;
-        }
-
-        fragment.appendChild(iconButton);
-
-        // Initialize the tooltip for the newly created icon.
-        const tooltip = new Tooltip(iconButton, {
-          delay: { show: 500, hide: 0 },
-        });
-        this.tooltips.push(tooltip);
-
-        // When the user clicks an icon, emit the select-icon event and add the
-        // selected class to the icon.
-        iconButton.addEventListener('click', () => {
-          if (this.selectedIconDiv) {
-            this.selectedIconDiv.classList.remove('selected');
-          }
-          iconButton.classList.add('selected');
-
-          this.selectedIcon = iconName;
-          this.selectedIconDiv = iconButton;
-
-          this.emit('select', iconName, this.themeSelect.value);
-        });
-
-        // When the user double-clicks an icon, emit the close event.
-        iconButton.addEventListener('dblclick', () => {
-          this.hide();
-        });
-      }
-
-      // Before actually modifying the DOM, check if the operation has been aborted.
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      this.iconGrid.appendChild(fragment);
-
-      startIndex = endIndex;
-
-      // If there are still icons pending, yield to let the UI thread continue a bit and
-      // then add the next batch of icons.
-      if (startIndex < icons.length) {
-        requestAnimationFrame(addBatch);
-      } else {
-        // The loading operation is finished. Clean up and scroll to the selected icon.
-        this.loadAbortController = null;
-        this.container.classList.remove('loading');
-
-        const scrollbox = this.iconGrid.parentElement.parentElement;
-        if (this.selectedIconDiv) {
-          scrollbox.scrollTop =
-            this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2 - 150;
-        }
-
-        // Create the observer that is used to detect when icons are scrolled into view.
-        // Once an icon is visible, the icon is loaded into the button. This is done to
-        // avoid loading all icons at once.
-        this.observer = new IntersectionObserver(
-          (entries) => {
-            entries.forEach((entry) => {
-              const iconButton = entry.target;
-              const iconName = iconButton.attributes.getNamedItem('icon-name').value;
-
-              if (entry.isIntersecting) {
-                iconButton.appendChild(theme.createDiv(iconName));
-              } else {
-                iconButton.innerHTML = '';
-              }
-            });
-          },
-          { root: scrollbox, delay: 250, rootMargin: '250px' }
-        );
-
-        // Observe all icons in the grid. We get the icons by querying the grid for all
-        // divs having the icon-name attribute.
-        const icons = this.iconGrid.querySelectorAll('div[icon-name]');
-        icons.forEach((icon) => this.observer.observe(icon));
-      }
-    };
-
-    // Start adding the first batch of icons.
-    addBatch();
+    this.picker.init(this.initialIcon);
+    this.picker.onSelect((icon) => this.emit('select', icon, theme));
+    this.picker.onClose(() => this.hide());
   }
 }

--- a/src/renderer/editor/properties/icon-picker.ts
+++ b/src/renderer/editor/properties/icon-picker.ts
@@ -137,7 +137,7 @@ export class IconPicker extends EventEmitter {
     this.picker = IconThemeRegistry.getInstance().createIconPicker(theme);
 
     this.pickerContainer.innerHTML = '';
-    this.pickerContainer.appendChild(this.picker.getElement());
+    this.pickerContainer.appendChild(this.picker.getFragment());
 
     this.picker.init(this.initialIcon);
     this.picker.onSelect((icon) => this.emit('select', icon, theme));

--- a/src/renderer/editor/properties/properties.ts
+++ b/src/renderer/editor/properties/properties.ts
@@ -15,7 +15,7 @@ import { IEditorMenuItem } from '../common/editor-menu-item';
 import { IMenu, IBackendInfo, IShowEditorOptions } from '../../../common';
 import { IconPicker } from './icon-picker';
 import { ConditionPicker } from './condition-picker';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { TextPicker } from './text-picker';
 import { ShortcutPicker } from './shortcut-picker';
 import { ShortcutIDPicker } from './shortcut-id-picker';
@@ -181,9 +181,10 @@ export class Properties extends EventEmitter {
         this.activeItem.icon = icon;
         this.activeItem.iconTheme = theme;
 
-        this.iconButton.innerHTML = IconThemeRegistry.getInstance()
-          .getTheme(theme)
-          .createDiv(icon).outerHTML;
+        this.iconButton.innerHTML = IconThemeRegistry.getInstance().createIcon(
+          theme,
+          icon
+        ).outerHTML;
 
         this.emit('changed-icon');
       }
@@ -357,9 +358,10 @@ export class Properties extends EventEmitter {
     this.activeItem = item;
     this.nameInput.value = item.name;
 
-    this.iconButton.innerHTML = IconThemeRegistry.getInstance()
-      .getTheme(item.iconTheme)
-      .createDiv(item.icon).outerHTML;
+    this.iconButton.innerHTML = IconThemeRegistry.getInstance().createIcon(
+      item.iconTheme,
+      item.icon
+    ).outerHTML;
 
     const settings = ItemConfigRegistry.getInstance().getConfigWidget(item);
 

--- a/src/renderer/editor/properties/style/index.scss
+++ b/src/renderer/editor/properties/style/index.scss
@@ -8,7 +8,6 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-@import './icon-picker.scss';
 @import './text-picker.scss';
 
 #kando-menu-properties-area {

--- a/src/renderer/editor/properties/templates/icon-picker.hbs
+++ b/src/renderer/editor/properties/templates/icon-picker.hbs
@@ -12,15 +12,13 @@
 <div class="fs-1 kando-font">{{strings/heading}}</div>
 <div class="fs-5 mb-3">{{{strings/subheading}}}</div>
 
-<div class='d-flex'>
-  <select class="form-select fs-3 kando-font form-control" id="kando-properties-icon-theme-select">
-    {{#each themes}}
-      <option value="{{key}}">{{name}}</option>
-    {{/each}}
-  </select>
-</div>
+<select class="form-select fs-3 kando-font form-control" id="kando-properties-icon-theme-select">
+  {{#each themes}}
+    <option value="{{key}}">{{name}}</option>
+  {{/each}}
+</select>
 
-<div id="kando-properties-icon-picker"></div>
+<div id="kando-properties-icon-picker" class='d-flex flex-column' style="height: 30vh; position: relative"></div>
 
 <div class='d-flex justify-content-end'>
   <button class="btn btn-secondary fs-3 kando-font me-3 my-3 px-5 ms-auto" id="kando-properties-icon-picker-cancel">{{strings/cancel}}</button>

--- a/src/renderer/editor/toolbar/add-items-tab.ts
+++ b/src/renderer/editor/toolbar/add-items-tab.ts
@@ -10,7 +10,7 @@
 
 import { ToolbarDraggable } from './toolbar-draggable';
 import { ItemTypeRegistry } from '../../../common/item-type-registry';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { DnDManager } from '../common/dnd-manager';
 import { IMenuItem } from '../../../common';
 
@@ -39,9 +39,10 @@ export class AddItemsTab {
       data.push({
         name: type.defaultName,
         description: type.genericDescription,
-        icon: IconThemeRegistry.getInstance()
-          .getTheme(type.defaultIconTheme)
-          .createDiv(type.defaultIcon).outerHTML,
+        icon: IconThemeRegistry.getInstance().createIcon(
+          type.defaultIconTheme,
+          type.defaultIcon
+        ).outerHTML,
         typeName,
       });
     });

--- a/src/renderer/editor/toolbar/menus-tab.ts
+++ b/src/renderer/editor/toolbar/menus-tab.ts
@@ -13,7 +13,7 @@ import i18next from 'i18next';
 import { ToolbarDraggable } from './toolbar-draggable';
 import { DropTargetTab } from './drop-target-tab';
 import { IMenu, IMenuSettings, deepCopyMenu } from '../../../common';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { IDraggable } from '../common/draggable';
 import { DnDManager } from '../common/dnd-manager';
 
@@ -98,9 +98,7 @@ export class MenusTab extends DropTargetTab {
     const parent = icon.parentElement;
     icon.remove();
     parent.append(
-      IconThemeRegistry.getInstance()
-        .getTheme(menu.root.iconTheme)
-        .createDiv(menu.root.icon)
+      IconThemeRegistry.getInstance().createIcon(menu.root.iconTheme, menu.root.icon)
     );
 
     // Update the shortcut.
@@ -144,9 +142,10 @@ export class MenusTab extends DropTargetTab {
       description:
         (this.showShortcutIDs ? menu.shortcutID : menu.shortcut) ||
         i18next.t('properties.common.not-bound'),
-      icon: IconThemeRegistry.getInstance()
-        .getTheme(menu.root.iconTheme)
-        .createDiv(menu.root.icon).outerHTML,
+      icon: IconThemeRegistry.getInstance().createIcon(
+        menu.root.iconTheme,
+        menu.root.icon
+      ).outerHTML,
       index,
     }));
 

--- a/src/renderer/editor/toolbar/templates-tab.ts
+++ b/src/renderer/editor/toolbar/templates-tab.ts
@@ -19,7 +19,7 @@ import {
   deepCopyMenuItem,
 } from '../../../common';
 import { ItemTypeRegistry } from '../../../common/item-type-registry';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { IDraggable } from '../common/draggable';
 import { DnDManager } from '../common/dnd-manager';
 import { ToolbarDraggable } from './toolbar-draggable';
@@ -115,9 +115,10 @@ export class TemplatesTab extends DropTargetTab {
           name: menu.root.name,
           description:
             (this.showShortcutIDs ? menu.shortcutID : menu.shortcut) || 'Not bound.',
-          icon: IconThemeRegistry.getInstance()
-            .getTheme(menu.root.iconTheme)
-            .createDiv(menu.root.icon).outerHTML,
+          icon: IconThemeRegistry.getInstance().createIcon(
+            menu.root.iconTheme,
+            menu.root.icon
+          ).outerHTML,
           index,
         };
       }
@@ -129,9 +130,8 @@ export class TemplatesTab extends DropTargetTab {
         isMenu: false,
         name: item.name,
         description: typeInfo?.getDescription(item),
-        icon: IconThemeRegistry.getInstance()
-          .getTheme(item.iconTheme)
-          .createDiv(item.icon).outerHTML,
+        icon: IconThemeRegistry.getInstance().createIcon(item.iconTheme, item.icon)
+          .outerHTML,
         index,
       };
     });

--- a/src/renderer/editor/toolbar/trash-tab.ts
+++ b/src/renderer/editor/toolbar/trash-tab.ts
@@ -15,7 +15,7 @@ import { ToolbarDraggable } from './toolbar-draggable';
 import { IMenu, IMenuItem, deepCopyMenu, deepCopyMenuItem } from '../../../common';
 import { IEditorMenuItem } from '../common/editor-menu-item';
 import { ItemTypeRegistry } from '../../../common/item-type-registry';
-import { IconThemeRegistry } from '../../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../../icon-themes/icon-theme-registry';
 import { IDraggable } from '../common/draggable';
 import { DnDManager } from '../common/dnd-manager';
 
@@ -97,9 +97,10 @@ export class TrashTab extends DropTargetTab {
           name: menu.root.name,
           description:
             (this.showShortcutIDs ? menu.shortcutID : menu.shortcut) || 'Not bound.',
-          icon: IconThemeRegistry.getInstance()
-            .getTheme(menu.root.iconTheme)
-            .createDiv(menu.root.icon).outerHTML,
+          icon: IconThemeRegistry.getInstance().createIcon(
+            menu.root.iconTheme,
+            menu.root.icon
+          ).outerHTML,
           index,
         };
       }
@@ -111,9 +112,8 @@ export class TrashTab extends DropTargetTab {
         isMenu: false,
         name: item.name,
         description: typeInfo?.getDescription(item),
-        icon: IconThemeRegistry.getInstance()
-          .getTheme(item.iconTheme)
-          .createDiv(item.icon).outerHTML,
+        icon: IconThemeRegistry.getInstance().createIcon(item.iconTheme, item.icon)
+          .outerHTML,
         index,
       };
     });

--- a/src/renderer/icon-themes/base64-theme.ts
+++ b/src/renderer/icon-themes/base64-theme.ts
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { IIconTheme } from './icon-theme-registry';
+import { Base64Picker } from './icon-pickers/base64-picker';
+
+/**
+ * This class implements an icon theme that allows the user to enter base64 encoded images
+ * directly.
+ */
+export class Base64Theme implements IIconTheme {
+  /** Returns a human-readable name of the icon theme. */
+  get name() {
+    return 'Base64';
+  }
+
+  /**
+   * Creates a div element that contains the icon with the given base64 encoded image.
+   *
+   * @param icon The base64 encoded image.
+   * @returns A div element that contains the icon.
+   */
+  createIcon(icon: string) {
+    const containerDiv = document.createElement('div');
+    containerDiv.classList.add('icon-container');
+
+    const img = document.createElement('img');
+    img.src = icon;
+
+    containerDiv.appendChild(img);
+
+    return containerDiv;
+  }
+
+  /**
+   * Creates an icon picker for this theme. The icon picker allows the user to pick an
+   * icon from the theme.
+   *
+   * @returns An icon picker for this theme.
+   */
+  createIconPicker() {
+    return new Base64Picker();
+  }
+}

--- a/src/renderer/icon-themes/emoji-theme.ts
+++ b/src/renderer/icon-themes/emoji-theme.ts
@@ -11,13 +11,13 @@
 import { matchSorter } from 'match-sorter';
 import emojis from 'emojilib';
 
-import { IIconTheme } from '../icon-theme-registry';
+import { IconListTheme } from './icon-list-theme';
 
 /**
  * This class implements an icon theme that uses emojis as icons. It uses the `emojilib`
  * package to get a list of emojis and their descriptions.
  */
-export class EmojiTheme implements IIconTheme {
+export class EmojiTheme extends IconListTheme {
   /**
    * This array contains all emojis and their descriptions. Each inner array contains the
    * emoji itself as first element and all descriptions as following elements.
@@ -25,6 +25,8 @@ export class EmojiTheme implements IIconTheme {
   private icons: Array<Array<string>> = [];
 
   constructor() {
+    super();
+
     // Transform the emoji lib object into a nested array where each inner array contains
     // the emoji itself and all descriptions.
     this.icons = Object.entries(emojis).map(([emoji, descriptors]) => {
@@ -56,7 +58,7 @@ export class EmojiTheme implements IIconTheme {
    * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string) {
+  createIcon(icon: string) {
     const containerDiv = document.createElement('div');
     containerDiv.classList.add('icon-container');
 

--- a/src/renderer/icon-themes/fallback-theme.ts
+++ b/src/renderer/icon-themes/fallback-theme.ts
@@ -8,30 +8,38 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { SimpleIconsTheme } from './simple-icons-theme';
+import { IIconPicker, IIconTheme } from './icon-theme-registry';
 
 /**
- * This class implements an icon theme that uses the Simple Icons font as icons. It colors
- * the icons using the `si--color` class.
+ * This class implements an icon theme that is used if the user has not selected a valid
+ * icon theme.
  */
-export class SimpleIconsColoredTheme extends SimpleIconsTheme {
-  /** Returns a human-readable name of the icon theme. */
+export class FallbackTheme implements IIconTheme {
+  /** Not required as this is not a user-selectable theme. */
   get name() {
-    return 'Simple Icons (Colored)';
+    return '';
   }
 
   /**
-   * Creates a div element that contains the icon with the given name.
+   * Creates a div with a question mark icon.
    *
-   * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string) {
-    const containerDiv = super.createDiv(icon);
+  createIcon() {
+    const containerDiv = document.createElement('div');
+    containerDiv.classList.add('icon-container');
 
-    const iconDiv = containerDiv.childNodes[0] as HTMLElement;
-    iconDiv.classList.add('si--color');
+    const iconDiv = document.createElement('i');
+    containerDiv.appendChild(iconDiv);
+
+    iconDiv.classList.add('emoji-icon');
+    iconDiv.innerText = '❓';
 
     return containerDiv;
+  }
+
+  /** Not required as this is not a user-selectable theme. */
+  createIconPicker(): IIconPicker {
+    return null;
   }
 }

--- a/src/renderer/icon-themes/file-icon-theme.ts
+++ b/src/renderer/icon-themes/file-icon-theme.ts
@@ -10,28 +10,29 @@
 
 import { matchSorter } from 'match-sorter';
 
-import { IIconTheme } from '../icon-theme-registry';
+import { IconListTheme } from './icon-list-theme';
+import { IFileIconThemeDescription } from '../../common';
 
 /**
- * This class implements an icon theme that uses the Material Symbols Rounded font as
- * icons.
+ * This class is used for custom icon themes loaded from a icon-themes directory on the
+ * user's file system.
  */
-export class MaterialSymbolsTheme implements IIconTheme {
-  /** This array contains all available icon names. It is initialized in the constructor. */
-  private iconNames: Array<string> = [];
-
-  constructor() {
-    // Load material symbols type definition as text file.
-    const string = require('!!raw-loader!material-symbols/index.d.ts').default;
-
-    // Use regex to extract all icon names. All the names are simply enclosed by quotes in
-    // the type definition file above, so the regex is quite simple.
-    this.iconNames = string.match(/"(.*?)"/g).map((name: string) => name.slice(1, -1));
+export class FileIconTheme extends IconListTheme {
+  /**
+   * Creates a new FileIconTheme.
+   *
+   * @param description The description of the icon theme.
+   */
+  constructor(private description: IFileIconThemeDescription) {
+    super();
   }
 
-  /** Returns a human-readable name of the icon theme. */
+  /**
+   * The name of the icon corresponds to the name of the directory in the icon-themes
+   * subdirectory of Kando's config directory.
+   */
   get name() {
-    return 'Material Symbols Rounded';
+    return this.description.name;
   }
 
   /**
@@ -41,7 +42,7 @@ export class MaterialSymbolsTheme implements IIconTheme {
    * @returns An array of icon names that match the search term.
    */
   public async listIcons(searchTerm: string) {
-    return matchSorter(this.iconNames, searchTerm);
+    return matchSorter(this.description.icons, searchTerm);
   }
 
   /**
@@ -50,15 +51,15 @@ export class MaterialSymbolsTheme implements IIconTheme {
    * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string) {
+  createIcon(icon: string) {
     const containerDiv = document.createElement('div');
     containerDiv.classList.add('icon-container');
 
-    const iconDiv = document.createElement('i');
-    containerDiv.appendChild(iconDiv);
+    const iconDiv = document.createElement('img');
+    iconDiv.src = `file://${this.description.directory}/${icon}`;
+    iconDiv.draggable = false;
 
-    iconDiv.classList.add('material-symbols-rounded');
-    iconDiv.innerText = icon;
+    containerDiv.appendChild(iconDiv);
 
     return containerDiv;
   }

--- a/src/renderer/icon-themes/icon-list-theme.ts
+++ b/src/renderer/icon-themes/icon-list-theme.ts
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { IIconTheme } from './icon-theme-registry';
+import { IconListPicker } from './icon-pickers/icon-list-picker';
+
+/**
+ * This class implements an icon theme that uses emojis as icons. It uses the `emojilib`
+ * package to get a list of emojis and their descriptions.
+ */
+export abstract class IconListTheme implements IIconTheme {
+  abstract name: string;
+
+  /**
+   * Returns a list icons from this theme that match the given search term. This can be
+   * implemented asynchronously if retrieving the list of icons is an expensive
+   * operation.
+   *
+   * @param searchTerm The search term to filter the icons.
+   * @returns A promise that resolves to an array of icon names that match the search
+   *   term.
+   */
+  abstract listIcons(searchTerm: string): Promise<Array<string>>;
+
+  // This method is still abstract and needs to be implemented by subclasses. See the docs
+  // of this method in the IIconTheme interface for more information.
+  abstract createIcon(icon: string): HTMLElement;
+
+  /**
+   * Creates an icon picker for this theme. The icon picker allows the user to pick an
+   * icon from the theme.
+   *
+   * @returns An icon picker for this theme.
+   */
+  createIconPicker() {
+    return new IconListPicker(this);
+  }
+}

--- a/src/renderer/icon-themes/icon-pickers/base64-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/base64-picker.ts
@@ -8,8 +8,6 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import i18next from 'i18next';
-
 import { IIconPicker } from '../icon-theme-registry';
 
 /**

--- a/src/renderer/icon-themes/icon-pickers/base64-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/base64-picker.ts
@@ -1,0 +1,84 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import i18next from 'i18next';
+
+import { IIconPicker } from '../icon-theme-registry';
+
+/**
+ * An icon picker which is only a text area. The user can enter a base64 encoded image
+ * directly.
+ */
+export class Base64Picker implements IIconPicker {
+  /** The container to which the icon picker is appended. */
+  private fragment: DocumentFragment = null;
+
+  /** The textarea where the user can enter a base64 encoded image. */
+  private textArea: HTMLTextAreaElement = null;
+
+  /** This callback is called when the user enters a valid base64 encoded image. */
+  private onSelectCallback: (icon: string) => void = null;
+
+  /** Creates a new IconPicker and appends it to the given container. */
+  constructor() {
+    this.fragment = document.createDocumentFragment();
+
+    this.textArea = document.createElement('textarea');
+    this.textArea.placeholder = 'data:image/svg;base64,...';
+    this.textArea.classList.add('base64-picker');
+    this.textArea.classList.add('form-control');
+    this.textArea.classList.add('my-3');
+
+    // Validate the input when the user types something.
+    this.textArea.addEventListener('input', async () => {
+      const img = new Image();
+      img.src = this.textArea.value;
+      const valid = await new Promise((resolve) => {
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+      });
+
+      if (valid) {
+        this.textArea.classList.remove('invalid');
+        this.onSelectCallback(this.textArea.value);
+      } else {
+        this.textArea.classList.add('invalid');
+      }
+    });
+
+    this.fragment.appendChild(this.textArea);
+  }
+
+  /** Returns the HTML fragment of the icon picker. */
+  public getFragment() {
+    return this.fragment;
+  }
+
+  /** Registers a callback that is called when the user selects an icon. */
+  public onSelect(callback: (icon: string) => void) {
+    this.onSelectCallback = callback;
+  }
+
+  /** Not used in this implementation. */
+  public onClose() {}
+
+  /**
+   * Initializes the icon picker. This method will be called after the icon picker is
+   * appended to the DOM.
+   *
+   * @param selectedIcon The icon that is currently selected.
+   */
+  public init(selectedIcon: string) {
+    this.textArea.value = selectedIcon;
+  }
+
+  /** Not used in this implementation. */
+  public deinit() {}
+}

--- a/src/renderer/icon-themes/icon-pickers/icon-list-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/icon-list-picker.ts
@@ -30,8 +30,8 @@ declare global {
  * even with a large number of icons.
  */
 export class IconListPicker implements IIconPicker {
-  /** The container to which the icon picker is appended. */
-  private element: HTMLElement = null;
+  /** The HTML elements of the icon picker. */
+  private fragment: DocumentFragment = null;
 
   /** This callback is called when the user selects an icon. */
   private onSelectCallback: (icon: string) => void = null;
@@ -44,6 +44,9 @@ export class IconListPicker implements IIconPicker {
 
   /** The div containing the grid of icons. */
   private iconGrid: HTMLElement = null;
+
+  /** The spinner. */
+  private spinner: HTMLElement = null;
 
   /** The icon that is currently selected. */
   private selectedIcon: string = null;
@@ -61,7 +64,11 @@ export class IconListPicker implements IIconPicker {
    */
   private tooltips: Tooltip[] = [];
 
-  /** Creates a new IconPicker and appends it to the given container. */
+  /**
+   * Creates a new IconPicker for the given theme.
+   *
+   * @param theme The theme for which the icon picker is created.
+   */
   constructor(private theme: IconListTheme) {
     const data = {
       strings: {
@@ -70,22 +77,23 @@ export class IconListPicker implements IIconPicker {
     };
 
     const template = require('./templates/icon-list-picker.hbs');
-    this.element = document.createElement('div');
-    this.element.innerHTML = template(data);
+    this.fragment = document.createRange().createContextualFragment(template(data));
 
-    // Store a reference to the icon grid, the filter input and the theme select field.
-    this.iconGrid = this.element.querySelector('.icon-list-picker-grid');
+    // Store a reference to the icon grid, the spinner, the filter input, and the theme
+    // select field.
+    this.iconGrid = this.fragment.querySelector('.icon-list-picker-grid');
+    this.spinner = this.fragment.querySelector('.icon-list-picker-spinner');
 
-    this.filterInput = this.element.querySelector(
+    this.filterInput = this.fragment.querySelector(
       '.icon-list-picker-filter'
     ) as HTMLInputElement;
 
     this.filterInput.addEventListener('input', () => this.loadIcons());
   }
 
-  /** Returns the HTML element of the icon picker. */
-  public getElement() {
-    return this.element;
+  /** Returns the HTML fragment of the icon picker. */
+  public getFragment() {
+    return this.fragment;
   }
 
   /** Registers a callback that is called when the user selects an icon. */
@@ -135,7 +143,8 @@ export class IconListPicker implements IIconPicker {
 
     // Clear existing icons.
     this.iconGrid.innerHTML = '';
-    this.element.classList.add('loading');
+    this.iconGrid.classList.add('loading');
+    this.spinner.classList.add('loading');
 
     if (this.observer) {
       this.observer.disconnect();
@@ -216,7 +225,8 @@ export class IconListPicker implements IIconPicker {
       } else {
         // The loading operation is finished. Clean up and scroll to the selected icon.
         this.loadAbortController = null;
-        this.element.classList.remove('loading');
+        this.iconGrid.classList.remove('loading');
+        this.spinner.classList.remove('loading');
 
         const scrollbox = this.iconGrid.parentElement.parentElement;
         if (this.selectedIconDiv) {

--- a/src/renderer/icon-themes/icon-pickers/icon-list-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/icon-list-picker.ts
@@ -1,0 +1,256 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import i18next from 'i18next';
+import { Tooltip } from 'bootstrap';
+
+import { IIconPicker } from '../icon-theme-registry';
+import { IconListTheme } from '../icon-list-theme';
+
+// Extend the IntersectionObserverInit interface to allow for a delay option. This delay
+// was introduced in IntersectionObserver v2 and is for some reason not yet part of the
+// TypeScript definitions.
+declare global {
+  interface IntersectionObserverInit {
+    delay?: number;
+  }
+}
+
+/**
+ * An icon picker for icon themes which consist of a larger list of icons. The icons are
+ * loaded asynchronously in batches to avoid blocking the UI thread. Also, icons are only
+ * shown when they are scrolled into view. Overall, this allows for decent performance
+ * even with a large number of icons.
+ */
+export class IconListPicker implements IIconPicker {
+  /** The container to which the icon picker is appended. */
+  private element: HTMLElement = null;
+
+  /** This callback is called when the user selects an icon. */
+  private onSelectCallback: (icon: string) => void = null;
+
+  /** This callback is called when the user wants to close the icon picker. */
+  private onCloseCallback: () => void = null;
+
+  /** The input field for filtering icons. */
+  private filterInput: HTMLInputElement = null;
+
+  /** The div containing the grid of icons. */
+  private iconGrid: HTMLElement = null;
+
+  /** The icon that is currently selected. */
+  private selectedIcon: string = null;
+  private selectedIconDiv: HTMLElement = null;
+
+  /** When a new loadIcons operation is started, the previous one is aborted. */
+  private loadAbortController: AbortController = null;
+
+  /** The observer that is used to detect when icons are scrolled into view. */
+  private observer: IntersectionObserver = null;
+
+  /**
+   * The tooltips of the icons in the grid. We need to keep track of them to remove them
+   * when the icon grid is reloaded.
+   */
+  private tooltips: Tooltip[] = [];
+
+  /** Creates a new IconPicker and appends it to the given container. */
+  constructor(private theme: IconListTheme) {
+    const data = {
+      strings: {
+        placeholder: i18next.t('properties.icon-picker.placeholder'),
+      },
+    };
+
+    const template = require('./templates/icon-list-picker.hbs');
+    this.element = document.createElement('div');
+    this.element.innerHTML = template(data);
+
+    // Store a reference to the icon grid, the filter input and the theme select field.
+    this.iconGrid = this.element.querySelector('.icon-list-picker-grid');
+
+    this.filterInput = this.element.querySelector(
+      '.icon-list-picker-filter'
+    ) as HTMLInputElement;
+
+    this.filterInput.addEventListener('input', () => this.loadIcons());
+  }
+
+  /** Returns the HTML element of the icon picker. */
+  public getElement() {
+    return this.element;
+  }
+
+  /** Registers a callback that is called when the user selects an icon. */
+  public onSelect(callback: (icon: string) => void) {
+    this.onSelectCallback = callback;
+  }
+
+  /** Registers a callback that is called when the icon picker should be closed. */
+  public onClose(callback: () => void) {
+    this.onCloseCallback = callback;
+  }
+
+  /**
+   * Initializes the icon picker. This method will be called after the icon picker is
+   * appended to the DOM.
+   *
+   * @param selectedIcon The icon that is currently selected.
+   */
+  public init(selectedIcon: string) {
+    this.selectedIcon = selectedIcon;
+    this.loadIcons();
+  }
+
+  /** Cancels the loading of icons. */
+  public deinit() {
+    if (this.loadAbortController) {
+      this.loadAbortController.abort();
+      this.loadAbortController = null;
+    }
+  }
+
+  /**
+   * Reloads the icons of the currently selected theme and updates the icon grid. The grid
+   * will scroll to the selected icon. The loading happens in batches to avoid blocking
+   * the UI thread for too long. When a previous loadIcons operation is still in progress,
+   * it is aborted.
+   */
+  private async loadIcons() {
+    // Check if there is a previous loadIcons operation in progress. If so, abort it.
+    if (this.loadAbortController) {
+      this.loadAbortController.abort();
+    }
+
+    // Create a new AbortController for the current operation.
+    const abortController = new AbortController();
+    this.loadAbortController = abortController;
+
+    // Clear existing icons.
+    this.iconGrid.innerHTML = '';
+    this.element.classList.add('loading');
+
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    // Clear the tooltips.
+    this.tooltips.forEach((tooltip) => tooltip.dispose());
+    this.tooltips = [];
+
+    const icons = await this.theme.listIcons(this.filterInput.value);
+
+    // We add the icons in batches to avoid blocking the UI thread for too long.
+    const batchSize = 150;
+    let startIndex = 0;
+
+    const addBatch = () => {
+      const endIndex = Math.min(startIndex + batchSize, icons.length);
+      const fragment = document.createDocumentFragment();
+      for (let i = startIndex; i < endIndex; i++) {
+        const iconName = icons[i];
+
+        const iconButton = document.createElement('div');
+
+        // Add the attributes required for the tooltip.
+        iconButton.setAttribute('data-bs-toggle', 'tooltip');
+        iconButton.setAttribute('title', iconName);
+
+        // The icon-name attribute is used when loading the icon when the button becomes
+        // visible.
+        iconButton.setAttribute('icon-name', iconName);
+
+        if (iconName === this.selectedIcon) {
+          iconButton.classList.add('selected');
+          this.selectedIconDiv = iconButton;
+        }
+
+        fragment.appendChild(iconButton);
+
+        // Initialize the tooltip for the newly created icon.
+        const tooltip = new Tooltip(iconButton, {
+          delay: { show: 500, hide: 0 },
+        });
+        this.tooltips.push(tooltip);
+
+        // When the user clicks an icon, emit the select-icon event and add the
+        // selected class to the icon.
+        iconButton.addEventListener('click', () => {
+          if (this.selectedIconDiv) {
+            this.selectedIconDiv.classList.remove('selected');
+          }
+          iconButton.classList.add('selected');
+
+          this.selectedIcon = iconName;
+          this.selectedIconDiv = iconButton;
+
+          this.onSelectCallback(iconName);
+        });
+
+        // When the user double-clicks an icon, emit the close event.
+        iconButton.addEventListener('dblclick', () => {
+          this.onCloseCallback();
+        });
+      }
+
+      // Before actually modifying the DOM, check if the operation has been aborted.
+      if (abortController.signal.aborted) {
+        return;
+      }
+
+      this.iconGrid.appendChild(fragment);
+
+      startIndex = endIndex;
+
+      // If there are still icons pending, yield to let the UI thread continue a bit and
+      // then add the next batch of icons.
+      if (startIndex < icons.length) {
+        requestAnimationFrame(addBatch);
+      } else {
+        // The loading operation is finished. Clean up and scroll to the selected icon.
+        this.loadAbortController = null;
+        this.element.classList.remove('loading');
+
+        const scrollbox = this.iconGrid.parentElement.parentElement;
+        if (this.selectedIconDiv) {
+          scrollbox.scrollTop =
+            this.selectedIconDiv.offsetTop - scrollbox.clientHeight / 2 - 150;
+        }
+
+        // Create the observer that is used to detect when icons are scrolled into view.
+        // Once an icon is visible, the icon is loaded into the button. This is done to
+        // avoid loading all icons at once.
+        this.observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              const iconButton = entry.target;
+              const iconName = iconButton.attributes.getNamedItem('icon-name').value;
+
+              if (entry.isIntersecting) {
+                iconButton.appendChild(this.theme.createIcon(iconName));
+              } else {
+                iconButton.innerHTML = '';
+              }
+            });
+          },
+          { root: scrollbox, delay: 250, rootMargin: '250px' }
+        );
+
+        // Observe all icons in the grid. We get the icons by querying the grid for all
+        // divs having the icon-name attribute.
+        const icons = this.iconGrid.querySelectorAll('div[icon-name]');
+        icons.forEach((icon) => this.observer.observe(icon));
+      }
+    };
+
+    // Start adding the first batch of icons.
+    addBatch();
+  }
+}

--- a/src/renderer/icon-themes/icon-pickers/style/base64-picker.scss
+++ b/src/renderer/icon-themes/icon-pickers/style/base64-picker.scss
@@ -1,0 +1,19 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+textarea.base64-picker {
+  transition: box-shadow 150ms ease;
+  resize: none;
+  flex-grow: 1;
+
+  &.invalid {
+    box-shadow: 0 0 15px rgba(255, 64, 64, 1) inset;
+  }
+}

--- a/src/renderer/icon-themes/icon-pickers/style/icon-list-picker.scss
+++ b/src/renderer/icon-themes/icon-pickers/style/icon-list-picker.scss
@@ -8,7 +8,7 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-#kando-menu-properties-icon-picker {
+.icon-list-picker {
   .spinner {
     $size: 128px;
 
@@ -42,13 +42,13 @@
     opacity: 1;
   }
 
-  &.loading #kando-properties-icon-picker-grid {
+  &.loading .icon-list-picker-grid {
     pointer-events: none;
     visibility: hidden;
   }
 }
 
-#kando-properties-icon-picker-grid {
+.icon-list-picker-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(calc(32px + 2vw), 1fr));
   transition: opacity 150ms ease;

--- a/src/renderer/icon-themes/icon-pickers/style/icon-list-picker.scss
+++ b/src/renderer/icon-themes/icon-pickers/style/icon-list-picker.scss
@@ -8,43 +8,36 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-.icon-list-picker {
-  .spinner {
-    $size: 128px;
+.icon-list-picker-spinner {
+  $size: 128px;
 
-    position: absolute;
-    top: calc(50% - $size / 2);
-    left: calc(50% - $size / 2);
+  position: absolute;
+  top: calc(50% - $size / 2);
+  left: calc(50% - $size / 2);
 
-    pointer-events: none;
-    opacity: 0;
+  pointer-events: none;
+  opacity: 0;
 
-    width: $size;
-    height: $size;
-    border-radius: 50%;
-    border-top: 3px solid #fff;
-    border-right: 3px solid transparent;
-    animation: spinnerRotation 1s linear infinite;
+  width: $size;
+  height: $size;
+  border-radius: 50%;
+  border-top: 3px solid #fff;
+  border-right: 3px solid transparent;
+  animation: spinnerRotation 1s linear infinite;
 
-    transition: opacity 500ms ease;
-  }
+  transition: opacity 500ms ease;
 
-  @keyframes spinnerRotation {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-
-  &.loading .spinner {
+  &.loading {
     opacity: 1;
   }
+}
 
-  &.loading .icon-list-picker-grid {
-    pointer-events: none;
-    visibility: hidden;
+@keyframes spinnerRotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
   }
 }
 
@@ -52,6 +45,11 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(calc(32px + 2vw), 1fr));
   transition: opacity 150ms ease;
+
+  &.loading {
+    pointer-events: none;
+    visibility: hidden;
+  }
 
   & > div {
     aspect-ratio: 1 / 1;

--- a/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
+++ b/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
@@ -9,20 +9,14 @@
 // SPDX-License-Identifier: MIT
 }}
 
-<div class="fs-1 kando-font">{{strings/heading}}</div>
-<div class="fs-5 mb-3">{{{strings/subheading}}}</div>
-
 <div class='d-flex'>
-  <select class="form-select fs-3 kando-font form-control" id="kando-properties-icon-theme-select">
-    {{#each themes}}
-      <option value="{{key}}">{{name}}</option>
-    {{/each}}
-  </select>
+  <input type="text" class="icon-list-picker-filter fs-3 kando-font form-control flex-grow-1 mt-3" placeholder="{{strings/placeholder}}" />
 </div>
 
-<div id="kando-properties-icon-picker"></div>
-
-<div class='d-flex justify-content-end'>
-  <button class="btn btn-secondary fs-3 kando-font me-3 my-3 px-5 ms-auto" id="kando-properties-icon-picker-cancel">{{strings/cancel}}</button>
-  <button class="btn btn-secondary fs-3 kando-font my-3 px-5" id="kando-properties-icon-picker-ok">{{strings/done}}</button>
+<div class='scrollbox mx-2' style="height: 30vh;">
+  <div class="scrollbox-content">
+    <div class="icon-list-picker-grid" class="justify-content-start"></div>
+  </div>
 </div>
+
+<span class="spinner"></span>

--- a/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
+++ b/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
@@ -9,14 +9,12 @@
 // SPDX-License-Identifier: MIT
 }}
 
-<div class='d-flex'>
-  <input type="text" class="icon-list-picker-filter fs-3 kando-font form-control flex-grow-1 mt-3" placeholder="{{strings/placeholder}}" />
-</div>
+<input type="text" class="icon-list-picker-filter fs-3 kando-font form-control flex-grow-1 mt-3" placeholder="{{strings/placeholder}}" />
 
-<div class='scrollbox mx-2' style="height: 30vh;">
+<div class='scrollbox mx-2'>
   <div class="scrollbox-content">
     <div class="icon-list-picker-grid" class="justify-content-start"></div>
   </div>
 </div>
 
-<span class="spinner"></span>
+<span class="icon-list-picker-spinner"></span>

--- a/src/renderer/icon-themes/icon-theme-registry.ts
+++ b/src/renderer/icon-themes/icon-theme-registry.ts
@@ -8,12 +8,48 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { SimpleIconsTheme } from './icon-themes/simple-icons-theme';
-import { SimpleIconsColoredTheme } from './icon-themes/simple-icons-colored-theme';
-import { MaterialSymbolsTheme } from './icon-themes/material-symbols-theme';
-import { EmojiTheme } from './icon-themes/emoji-theme';
-import { FileIconTheme } from './icon-themes/file-icon-theme';
-import { FallbackTheme } from './icon-themes/fallback-theme';
+import { SimpleIconsTheme } from './simple-icons-theme';
+import { SimpleIconsColoredTheme } from './simple-icons-colored-theme';
+import { MaterialSymbolsTheme } from './material-symbols-theme';
+import { EmojiTheme } from './emoji-theme';
+import { FileIconTheme } from './file-icon-theme';
+import { FallbackTheme } from './fallback-theme';
+
+/**
+ * This interface describes an icon picker. An icon picker is a UI element that allows the
+ * user to pick an icon from an icon theme.
+ */
+export interface IIconPicker {
+  /**
+   * Registers a callback that is called when the user selects an icon.
+   *
+   * @param callback A callback that is called when the user selects an icon. The callback
+   *   receives the selected icon as an argument.
+   */
+  onSelect(callback: (icon: string) => void): void;
+
+  /**
+   * Registers a callback that is called when the icon picker should be closed. This could
+   * be for instance if the user double-clicks an icon.
+   *
+   * @param callback A callback that is called when the icon picker should be closed.
+   */
+  onClose(callback: () => void): void;
+
+  /**
+   * Initializes the icon picker. This method will be called after the icon picker is
+   * appended to the DOM.
+   *
+   * @param selectedIcon The icon that is currently selected.
+   */
+  init(selectedIcon: string): void;
+
+  /** Can be used to clean up resources when the icon picker is no longer needed. */
+  deinit(): void;
+
+  /** Returns the HTML element of the icon picker. */
+  getElement(): HTMLElement;
+}
 
 /**
  * This interface describes an icon theme. An icon theme is a collection of icons that can
@@ -25,23 +61,20 @@ export interface IIconTheme {
   name: string;
 
   /**
-   * Returns a list icons from this theme that match the given search term. This can be
-   * implemented asynchronously if retrieving the list of icons is an expensive
-   * operation.
-   *
-   * @param searchTerm The search term to filter the icons.
-   * @returns A promise that resolves to an array of icon names that match the search
-   *   term.
-   */
-  listIcons(searchTerm: string): Promise<Array<string>>;
-
-  /**
    * Creates a div element that contains the icon with the given name.
    *
    * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string): HTMLElement;
+  createIcon(icon: string): HTMLElement;
+
+  /**
+   * Creates an IIconPicker instance that allows the user to pick an icon from the icon
+   * theme.
+   *
+   * @returns An IIconPicker instance.
+   */
+  createIconPicker(): IIconPicker;
 }
 
 /**
@@ -117,5 +150,27 @@ export class IconThemeRegistry {
    */
   public getTheme(key: string): IIconTheme {
     return this.iconThemes.get(key) || this.fallbackTheme;
+  }
+
+  /**
+   * Create an icon div from the given icon name.
+   *
+   * @param theme The icon theme to use.
+   * @param icon The name of the icon.
+   * @returns A div element that contains the icon.
+   */
+  public createIcon(theme: string, icon: string): HTMLElement {
+    return this.getTheme(theme).createIcon(icon);
+  }
+
+  /**
+   * Creates an IIConPicker instance that allows the user to pick an icon from the icon
+   * theme.
+   *
+   * @param theme The icon theme to use.
+   * @returns An IIconPicker instance.
+   */
+  createIconPicker(theme: string): IIconPicker {
+    return this.getTheme(theme).createIconPicker();
   }
 }

--- a/src/renderer/icon-themes/icon-theme-registry.ts
+++ b/src/renderer/icon-themes/icon-theme-registry.ts
@@ -14,6 +14,7 @@ import { MaterialSymbolsTheme } from './material-symbols-theme';
 import { EmojiTheme } from './emoji-theme';
 import { FileIconTheme } from './file-icon-theme';
 import { FallbackTheme } from './fallback-theme';
+import { Base64Theme } from './base64-theme';
 
 /**
  * This interface describes an icon picker. An icon picker is a UI element that allows the
@@ -47,8 +48,8 @@ export interface IIconPicker {
   /** Can be used to clean up resources when the icon picker is no longer needed. */
   deinit(): void;
 
-  /** Returns the HTML element of the icon picker. */
-  getElement(): HTMLElement;
+  /** Returns the HTML fragment of the icon picker. */
+  getFragment(): DocumentFragment;
 }
 
 /**
@@ -103,6 +104,7 @@ export class IconThemeRegistry {
     this.iconThemes.set('simple-icons-colored', new SimpleIconsColoredTheme());
     this.iconThemes.set('material-symbols-rounded', new MaterialSymbolsTheme());
     this.iconThemes.set('emoji', new EmojiTheme());
+    this.iconThemes.set('base64', new Base64Theme());
 
     // Add an icon theme for all icon themes in the user's icon theme directory.
     window.api.getIconThemes().then((info) => {

--- a/src/renderer/icon-themes/material-symbols-theme.ts
+++ b/src/renderer/icon-themes/material-symbols-theme.ts
@@ -10,27 +10,30 @@
 
 import { matchSorter } from 'match-sorter';
 
-import { IIconTheme } from '../icon-theme-registry';
-import { IFileIconThemeDescription } from '..';
+import { IconListTheme } from './icon-list-theme';
 
 /**
- * This class is used for custom icon themes loaded from a icon-themes directory on the
- * user's file system.
+ * This class implements an icon theme that uses the Material Symbols Rounded font as
+ * icons.
  */
-export class FileIconTheme implements IIconTheme {
-  /**
-   * Creates a new FileIconTheme.
-   *
-   * @param description The description of the icon theme.
-   */
-  constructor(private description: IFileIconThemeDescription) {}
+export class MaterialSymbolsTheme extends IconListTheme {
+  /** This array contains all available icon names. It is initialized in the constructor. */
+  private iconNames: Array<string> = [];
 
-  /**
-   * The name of the icon corresponds to the name of the directory in the icon-themes
-   * subdirectory of Kando's config directory.
-   */
+  constructor() {
+    super();
+
+    // Load material symbols type definition as text file.
+    const string = require('!!raw-loader!material-symbols/index.d.ts').default;
+
+    // Use regex to extract all icon names. All the names are simply enclosed by quotes in
+    // the type definition file above, so the regex is quite simple.
+    this.iconNames = string.match(/"(.*?)"/g).map((name: string) => name.slice(1, -1));
+  }
+
+  /** Returns a human-readable name of the icon theme. */
   get name() {
-    return this.description.name;
+    return 'Material Symbols Rounded';
   }
 
   /**
@@ -40,7 +43,7 @@ export class FileIconTheme implements IIconTheme {
    * @returns An array of icon names that match the search term.
    */
   public async listIcons(searchTerm: string) {
-    return matchSorter(this.description.icons, searchTerm);
+    return matchSorter(this.iconNames, searchTerm);
   }
 
   /**
@@ -49,15 +52,15 @@ export class FileIconTheme implements IIconTheme {
    * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string) {
+  createIcon(icon: string) {
     const containerDiv = document.createElement('div');
     containerDiv.classList.add('icon-container');
 
-    const iconDiv = document.createElement('img');
-    iconDiv.src = `file://${this.description.directory}/${icon}`;
-    iconDiv.draggable = false;
-
+    const iconDiv = document.createElement('i');
     containerDiv.appendChild(iconDiv);
+
+    iconDiv.classList.add('material-symbols-rounded');
+    iconDiv.innerText = icon;
 
     return containerDiv;
   }

--- a/src/renderer/icon-themes/simple-icons-colored-theme.ts
+++ b/src/renderer/icon-themes/simple-icons-colored-theme.ts
@@ -8,37 +8,29 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { IIconTheme } from '../icon-theme-registry';
+import { SimpleIconsTheme } from './simple-icons-theme';
 
 /**
- * This class implements an icon theme that is used if the user has not selected a valid
- * icon theme.
+ * This class implements an icon theme that uses the Simple Icons font as icons. It colors
+ * the icons using the `si--color` class.
  */
-export class FallbackTheme implements IIconTheme {
-  /** Not required as this is not a user-selectable theme. */
+export class SimpleIconsColoredTheme extends SimpleIconsTheme {
+  /** Returns a human-readable name of the icon theme. */
   get name() {
-    return '';
-  }
-
-  /** Not required as this is not a user-selectable theme. */
-  public async listIcons(): Promise<Array<string>> {
-    return [];
+    return 'Simple Icons (Colored)';
   }
 
   /**
-   * Creates a div with a question mark icon.
+   * Creates a div element that contains the icon with the given name.
    *
+   * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv() {
-    const containerDiv = document.createElement('div');
-    containerDiv.classList.add('icon-container');
+  createIcon(icon: string) {
+    const containerDiv = super.createIcon(icon);
 
-    const iconDiv = document.createElement('i');
-    containerDiv.appendChild(iconDiv);
-
-    iconDiv.classList.add('emoji-icon');
-    iconDiv.innerText = '❓';
+    const iconDiv = containerDiv.childNodes[0] as HTMLElement;
+    iconDiv.classList.add('si--color');
 
     return containerDiv;
   }

--- a/src/renderer/icon-themes/simple-icons-theme.ts
+++ b/src/renderer/icon-themes/simple-icons-theme.ts
@@ -10,14 +10,16 @@
 
 import { matchSorter } from 'match-sorter';
 
-import { IIconTheme } from '../icon-theme-registry';
+import { IconListTheme } from './icon-list-theme';
 
 /** This class implements an icon theme that uses the Simple Icons font as icons. */
-export class SimpleIconsTheme implements IIconTheme {
+export class SimpleIconsTheme extends IconListTheme {
   /** This array contains all available icon names. It is initialized in the constructor. */
   private iconNames: Array<string> = [];
 
   constructor() {
+    super();
+
     // Load simple-icons.css as text file.
     const string =
       require('!!raw-loader!simple-icons-font/font/simple-icons.css').default;
@@ -54,7 +56,7 @@ export class SimpleIconsTheme implements IIconTheme {
    * @param icon One of the icons returned by `listIcons`.
    * @returns A div element that contains the icon.
    */
-  createDiv(icon: string) {
+  createIcon(icon: string) {
     const containerDiv = document.createElement('div');
     containerDiv.classList.add('icon-container');
 

--- a/src/renderer/menu/menu-theme.ts
+++ b/src/renderer/menu/menu-theme.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import { IMenuThemeDescription } from '../../common';
-import { IconThemeRegistry } from '../../common/icon-theme-registry';
+import { IconThemeRegistry } from '../icon-themes/icon-theme-registry';
 import { closestEquivalentAngle } from '../math';
 import { IRenderedMenuItem } from './rendered-menu-item';
 
@@ -167,9 +167,10 @@ export class MenuTheme {
       if (layer.content === 'name') {
         layerDiv.innerText = item.name;
       } else if (layer.content === 'icon') {
-        const icon = IconThemeRegistry.getInstance()
-          .getTheme(item.iconTheme)
-          .createDiv(item.icon);
+        const icon = IconThemeRegistry.getInstance().createIcon(
+          item.iconTheme,
+          item.icon
+        );
         layerDiv.appendChild(icon);
       }
 


### PR DESCRIPTION
This adds a new icon theme: "Base64". This allows you to directly embed base64 encoded images. This will be especially helpful for menus which are dynamically generate via some sort of API in the future.