### PR TITLE
Hide chrome

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,10 +26,17 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - **Paste-Text Action:** You can now paste text into the currently focused window using the new "Paste Text" action. This uses your clipboard internally, so it can paste any text including special characters like emojis 🎊!
 - **Support for base64 icons:** This allows you to directly embed base64 encoded images. This will be especially helpful for menus which are dynamically generated via some sort of API in the future. Use `"base64"` as the icon theme and provide the base64 encoded image as the `"icon"`. This will be a string starting with something like `"data:image/svg+xml;base64, ..."`. This even supports animated gifs!
 - An option to the menu editor which **allows warping the mouse pointer to the center of the menu** when the menu is opened in centered mode. This allows to directly engage in turbo mode even if the menu is shown at the center of the screen.
-- **Change the fade-in and fade-out duration of the menu:** For now, it is only possible to change this via the `"menuOptions": {"fadeInDuration": 150}` and `"menuOptions": {"fadeOutDuration": 250}` properties in the `config.json` file. In the future, this will be exposed in the settings UI.
-- **Disable Marking Mode and Turbo Mode altogether:** This can be useful if you never use these features and want to avoid accidental selections. For now, this can be done via the `"menuOptions": {"enableMarkingMode": true}` and `"menuOptions": {"enableTurboMode": true}` in your `config.json`. In the future, this will be exposed in the settings UI.
-- **Select parent with mouse and keyboard:** Your mouse's navigate-back button as well as <kbd>Backspace</kbd> will now select the parent menu.
-- **Optionally select parent with RMB:** If you set `"menuOptions": {"rmbSelectsParent": true}`, your right mouse button will now select the parent menu instead of closing the menu.
+- **Adjustable fade-in and fade-out duration of the menu:** For now, it is only possible to change this via the `"menuOptions": {"fadeInDuration": 150}` and `"menuOptions": {"fadeOutDuration": 250}` properties in the `config.json` file. In the future, this will be exposed in the settings UI.
+- **Possibility to hide sidebar and editor buttons:** You can now add
+  ```json
+  "editorOptions": {
+    "showSidebarButtonVisible": false,
+    "showEditorButtonVisible": false
+  }
+  ```
+  to your `config.json` to hide the show-sidebar and the show-editor buttons respectively. They will still be clickable, so you can still use them if you aim carefully.
+- **Possibility to disable Marking Mode and Turbo Mode altogether:** This can be useful if you never use these features and want to avoid accidental selections. For now, this can be done via the `"menuOptions": {"enableMarkingMode": true}` and `"menuOptions": {"enableTurboMode": true}` in your `config.json`. In the future, this will be exposed in the settings UI.
+- **New options to select parent with mouse and keyboard:** Your mouse's navigate-back button as well as <kbd>Backspace</kbd> will now select the parent menu. Also, if you set `"menuOptions": {"rmbSelectsParent": true}`, your right mouse button will now select the parent menu instead of closing the menu.
 - **More configurable properties:** Some variables which were constants before are now configurable via the `config.json`. See the [corresponding documentation](https://github.com/kando-menu/kando/blob/main/docs/config-files.md#the-menuoptions-property) for details.
 - **Icon themes are now also loaded from the installation directory:** This can be interesting if you are packaging icon themes using a package manager. However, as an end user, you should not put your icon themes there, as they might be overwritten during an update. The directory is `resources/app/.webpack/renderer/assets/icon-themes/`.
 - **Several  translation updates:** Thanks to all the contributors!

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -37,6 +37,7 @@ Property | Default Value | Description
 `zoomFactor` | `1.0` | The zoom factor of the menu. This can be used to scale the menu on high-resolution screens.
 `enableVersionCheck` | `true` | If set to `true`, Kando will check for new version regularly, and show a notification if a new version is available.
 `menuOptions` | _see below_ | The parameters configure the general behavior of the menus.
+`editorOptions` | _see below_ | The parameters configure the behavior of the menu editor.
 
 ### The `menuOptions` Property
 
@@ -54,6 +55,13 @@ Property | Default Value | Description
 `gestureJitterThreshold` | `10` | Smaller pointer movements will not be considered at all during gesture recognition (in pixels).
 `gesturePauseTimeout` | `100` | If the pointer is stationary for this many milliseconds, the current item will be selected during gesture recognition.
 `rmbSelectsParent` | `false` | If enabled, the parent of a selected item will be selected on a right mouse button click. Else the menu will be closed directly.
+
+### The `editorOptions` Property
+
+Property | Default Value | Description
+-------- | ------------- | -----------
+`showSidebarButtonVisible` | `true` | Set this to `false` to hide the show-sidebar button. It will still be clickable, though.
+`showEditorButtonVisible` | `true` | Set this to `false` to hide the show-editor button. It will still be clickable, though.
 
 ## The Menu Configuration: `menus.json`
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -21,6 +21,9 @@ There are three ways to open the menu editor:
 In the editor, you can create new menus, and edit existing menus.
 Drag new items from the toolbar to the menu preview, reorder them, and change their properties on the right side of the screen.
 
+> [!TIP]
+> There are several advanced options which are not yet exposed in the editor UI. See the [Config-File Documentation](config-files.md) for all advanced options.
+
 ## Tips for Creating Efficient Menu Layouts :rocket:
 
 When designing your own menus, keep the following tips in mind:

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MenuOptions } from '../renderer/menu/menu';
+import { EditorOptions } from '../renderer/editor/editor';
 
 /**
  * A simple 2D vector.
@@ -431,4 +432,7 @@ export interface IAppSettings {
 
   /** The options which are passed to the menu. */
   menuOptions: MenuOptions;
+
+  /** The options which are passed to the menu editor. */
+  editorOptions: EditorOptions;
 }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -136,6 +136,10 @@ export class KandoApp {
           gesturePauseTimeout: 100,
           rmbSelectsParent: false,
         },
+        editorOptions: {
+          showSidebarButtonVisible: true,
+          showEditorButtonVisible: true,
+        },
       },
     });
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -11,7 +11,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import chokidar from 'chokidar';
-import isEqual from 'lodash.isequal';
+import lodash from 'lodash';
 
 /**
  * This type is used to define all possible events which can be emitted by the
@@ -253,7 +253,7 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
     try {
       console.log('Loading settings from', this.filePath);
       const data = fs.readJSONSync(this.filePath);
-      return { ...defaultSettings, ...data };
+      return lodash.merge({}, defaultSettings, data);
     } catch (error) {
       if (error.code === 'ENOENT') {
         // The settings file does not exist yet. Create it.
@@ -288,7 +288,7 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
     for (const key in newSettings) {
       if (
         Object.prototype.hasOwnProperty.call(newSettings, key) &&
-        !isEqual(newSettings[key], oldSettings[key])
+        !lodash.isEqual(newSettings[key], oldSettings[key])
       ) {
         this.emit(key, this.settings[key], oldSettings[key]);
       }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -78,7 +78,12 @@ Promise.all([
     menuTheme,
     settings.menuOptions
   );
-  const editor = new Editor(document.getElementById('kando-editor'), info);
+
+  const editor = new Editor(
+    document.getElementById('kando-editor'),
+    info,
+    settings.editorOptions
+  );
 
   // Show the menu when the main process requests it.
   window.api.showMenu((root, menuOptions, editorOptions) => {
@@ -103,8 +108,9 @@ Promise.all([
     document.getElementById('sidebar-show-new-version-button').classList.remove('d-none');
   });
 
-  // Tell the menu about settings changes.
-  window.api.appSettings.onChange('menuOptions', (options) => menu.setOptions(options));
+  // Tell the menu and the editor about settings changes.
+  window.api.appSettings.onChange('menuOptions', (o) => menu.setOptions(o));
+  window.api.appSettings.onChange('editorOptions', (o) => editor.setOptions(o));
 
   // Sometimes, the user may select an item too close to the edge of the screen. In this
   // case, we can not open the menu directly under the pointer. To make sure that the

--- a/src/renderer/editor/editor.ts
+++ b/src/renderer/editor/editor.ts
@@ -27,6 +27,18 @@ import {
 } from '../../common';
 import { DnDManager } from './common/dnd-manager';
 
+/** These options can be given to the constructor of the menu editor. */
+export class EditorOptions {
+  /**
+   * Set this to false to hide the show-sidebar button. It will still be clickable,
+   * though.
+   */
+  showSidebarButtonVisible = true;
+
+  /** Set this to false to hide the show-editor button. It will still be clickable, though. */
+  showEditorButtonVisible = true;
+}
+
 /**
  * This class is responsible for the entire editor. It contains the preview, the
  * properties view, the sidebar and the toolbar. It is an event emitter and will emit the
@@ -41,6 +53,12 @@ export class Editor extends EventEmitter {
 
   /** This is the backend info which is retrieved from the main process. */
   private backend: IBackendInfo = null;
+
+  /**
+   * This holds some global options for the menu editor. These options can be set when the
+   * editor is created and will be used to configure it's behavior.
+   */
+  private options: EditorOptions = null;
 
   /**
    * The background is an opaque div which is shown when the editor is open. It
@@ -97,12 +115,23 @@ export class Editor extends EventEmitter {
   /**
    * This constructor creates the HTML elements for the menu editor and wires up all the
    * functionality.
+   *
+   * @param container All the menu editor components will be appended to this container.
+   * @param backend Provides information on the currently used backend of Kando.
+   * @param options Use this to tweak the behavior of the menu editor.
    */
-  constructor(container: HTMLElement, backend: IBackendInfo) {
+  constructor(
+    container: HTMLElement,
+    backend: IBackendInfo,
+    options: Partial<EditorOptions> = {}
+  ) {
     super();
 
     this.container = container;
     this.backend = backend;
+
+    // Use the default options and overwrite them with the given options.
+    this.setOptions({ ...new EditorOptions(), ...options });
 
     // Initialize the background.
     this.background = new Background();
@@ -172,6 +201,25 @@ export class Editor extends EventEmitter {
         delay: { show: 500, hide: 0 },
       });
     });
+  }
+
+  /**
+   * Allow changing the options at run-time.
+   *
+   * @param options The new options.
+   */
+  public setOptions(options: Partial<EditorOptions>) {
+    this.options = { ...this.options, ...options };
+
+    this.container.style.setProperty(
+      '--show-sidebar-button-opacity',
+      `${this.options.showSidebarButtonVisible ? 1 : 0}`
+    );
+
+    this.container.style.setProperty(
+      '--show-editor-button-opacity',
+      `${this.options.showEditorButtonVisible ? 1 : 0}`
+    );
   }
 
   /**

--- a/src/renderer/editor/sidebar/style/index.scss
+++ b/src/renderer/editor/sidebar/style/index.scss
@@ -26,6 +26,13 @@
 #kando-editor.visible #hide-sidebar-button.visible {
   pointer-events: all;
   transform: translateX(0px);
+}
+
+#kando-editor.visible #show-sidebar-button.visible {
+  opacity: var(--show-sidebar-button-opacity);
+}
+
+#kando-editor.visible #hide-sidebar-button.visible {
   opacity: 1;
 }
 

--- a/src/renderer/editor/toolbar/style/index.scss
+++ b/src/renderer/editor/toolbar/style/index.scss
@@ -25,6 +25,14 @@
 #kando-editor.visible.edit-mode #leave-edit-mode-button {
   pointer-events: all;
   transform: translateY(0px);
+  opacity: var(--show-editor-button-opacity);
+}
+
+#kando-editor.visible:not(.edit-mode) #enter-edit-mode-button {
+  opacity: var(--show-editor-button-opacity);
+}
+
+#kando-editor.visible.edit-mode #leave-edit-mode-button {
   opacity: 1;
 }
 

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -162,6 +162,7 @@ export class Menu extends EventEmitter {
    *
    * @param container The HTML element which contains the menu.
    * @param theme The theme to use for rendering the menu.
+   * @param options Use this to tweak the behavior of the menu.
    */
   constructor(
     private container: HTMLElement,
@@ -174,21 +175,6 @@ export class Menu extends EventEmitter {
 
     // Use the default options and overwrite them with the given options.
     this.setOptions({ ...new MenuOptions(), ...options });
-
-    // Store the fade-in and fade-out durations as CSS variables.
-    CSS.registerProperty({
-      name: '--fade-in-duration',
-      syntax: '<time>',
-      inherits: false,
-      initialValue: `${this.options.fadeInDuration}ms`,
-    });
-
-    CSS.registerProperty({
-      name: '--fade-out-duration',
-      syntax: '<time>',
-      inherits: false,
-      initialValue: `${this.options.fadeOutDuration}ms`,
-    });
 
     this.pointerInput.onCloseMenu(() => {
       if (this.options.rmbSelectsParent) {


### PR DESCRIPTION
This adds the possibility to hide sidebar and editor buttons. You can now add
```json
"editorOptions": {
  "showSidebarButtonVisible": false,
  "showEditorButtonVisible": false
}
```
to your `config.json` to hide the show-sidebar and the show-editor buttons respectively. They will still be clickable, so you can still use them if you aim carefully.

This resolves #419.