### PR TITLE
Add '--define _build_id_links none' to the rpmbuild command

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### :bug: Fixed
 
 - A regression which allowed selecting items with the right mouse button in marking or turbo mode.
+- The RPM package now does not contain the debug information in `/usr/lib/.build-id` anymore. This should avoid any conflicts with other Electron-based applications.
 
 ## [Kando 1.5.1](https://github.com/kando-menu/kando/releases/tag/v1.5.1)
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,6 +12,81 @@ import { WebpackPlugin } from '@electron-forge/plugin-webpack';
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
 
+// This is used to create the Windows installer. See the link below for the available options.
+// https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel.InternalOptions.SquirrelWindowsOptions.html
+const makerSquirrel = new MakerSquirrel({});
+
+// This is used on all platforms to create a ZIP archive of the app. See the link below for the
+// available options.
+// https://js.electronforge.io/interfaces/_electron_forge_maker_zip.MakerZIPConfig.html
+const makerZIP = new MakerZIP({});
+
+// This is used to create the macOS DMG file. See the link below for the available options.
+// https://js.electronforge.io/interfaces/_electron_forge_maker_dmg.MakerDMGConfig.html
+const makerDMG = new MakerDMG({
+  appPath: '', // https://github.com/electron/forge/issues/3712
+});
+
+// This is used to create the DEB package for Linux. See the link below for the available options.
+// https://js.electronforge.io/interfaces/_electron_forge_maker_deb.InternalOptions.MakerDebConfigOptions.html
+const makerDeb = new MakerDeb({
+  options: {
+    productName: 'Kando',
+    genericName: 'Pie Menu',
+    icon: 'assets/icons/icon.svg',
+    homepage: 'https://github.com/kando-menu/kando',
+    depends: ['libxtst6'],
+    categories: ['Utility'],
+  },
+});
+
+// This is used to create the RPM package for Linux. See the link below for the available options.
+// https://js.electronforge.io/interfaces/_electron_forge_maker_rpm.InternalOptions.MakerRpmConfigOptions.html
+const makerRPM = new MakerRpm({
+  options: {
+    productName: 'Kando',
+    genericName: 'Pie Menu',
+    icon: 'assets/icons/icon.svg',
+    homepage: 'https://github.com/kando-menu/kando',
+    requires: ['libXtst'],
+    categories: ['Utility'],
+  },
+});
+
+// Below comes an evil hack to fix this issue: https://github.com/kando-menu/kando/issues/502
+// For some reason, there seems to be no way to disable the build_id_links feature in the
+// electron-installer-redhat package which is used by electron-forge to create RPM packages.
+// The rpmbuild command is issued here: https://github.com/electron-userland/electron-installer-redhat/blob/main/src/installer.js#L66
+// And we need to pass the "--define _build_id_links none" argument to it. Hence we override the
+// createPackage method of the RedhatInstaller class to add this argument. This is a dirty hack
+// and will most likely break in the future... Does anyone have a better solution?
+if (makerRPM.isSupportedOnCurrentPlatform()) {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { Installer: RedhatInstaller } = require('electron-installer-redhat');
+  const { spawn } = require('@malept/cross-spawn-promise');
+  RedhatInstaller.prototype.createPackage = async function () {
+    this.options.logger(
+      "+++ Running patched createPackage method! See Kando's forge.config.ts for details. +++"
+    );
+    this.options.logger(`Creating package at ${this.stagingDir}`);
+    const output = await spawn(
+      'rpmbuild',
+      [
+        '-bb',
+        this.specPath,
+        '--target',
+        `${this.options.arch}-${this.options.vendor}-${this.options.platform}`,
+        '--define',
+        `_topdir ${this.stagingDir}`,
+        '--define', // Here is the important part:
+        '_build_id_links none', // This is the argument we need to add.
+      ],
+      this.options.logger
+    );
+    this.options.logger(`rpmbuild output: ${output}`);
+  };
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     // https://electron.github.io/packager/main/interfaces/Options.html
@@ -24,39 +99,7 @@ const config: ForgeConfig = {
     },
   },
   rebuildConfig: {},
-  makers: [
-    new MakerSquirrel({
-      // https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel.InternalOptions.SquirrelWindowsOptions.html
-    }),
-    new MakerZIP({
-      // https://js.electronforge.io/interfaces/_electron_forge_maker_zip.MakerZIPConfig.html
-    }),
-    new MakerDMG({
-      appPath: '', // https://github.com/electron/forge/issues/3712
-    }),
-    new MakerRpm({
-      // https://js.electronforge.io/interfaces/_electron_forge_maker_rpm.InternalOptions.MakerRpmConfigOptions.html
-      options: {
-        productName: 'Kando',
-        genericName: 'Pie Menu',
-        icon: 'assets/icons/icon.svg',
-        homepage: 'https://github.com/kando-menu/kando',
-        requires: ['libXtst'],
-        categories: ['Utility'],
-      },
-    }),
-    new MakerDeb({
-      // https://js.electronforge.io/interfaces/_electron_forge_maker_deb.InternalOptions.MakerDebConfigOptions.html
-      options: {
-        productName: 'Kando',
-        genericName: 'Pie Menu',
-        icon: 'assets/icons/icon.svg',
-        homepage: 'https://github.com/kando-menu/kando',
-        depends: ['libxtst6'],
-        categories: ['Utility'],
-      },
-    }),
-  ],
+  makers: [makerSquirrel, makerZIP, makerDMG, makerDeb, makerRPM],
   plugins: [
     new WebpackPlugin({
       // We add "'self' file: data:" to the default-src directive for images and CSS files


### PR DESCRIPTION
This resolves #502 in a very ugly way. But currently I do not see a good alternative.