### PR TITLE
:wrench: Detach child processes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### :wrench: Changed
 
 - The show-sidebar and show-editor buttons are now shown when hovered even if they are made invisible via the `config.json`.
+- How processes are spawned by the command action. They are now detached from the parent process. This should prevent launched applications from being closed when Kando is closed.
 - If `XDG_SESSION_TYPE` is set to `tty`, Kando will now try to use the X11 backend on Linux instead of refusing to start. In most cases, this should work. But there will be a warning in the console if the X11 backend is used in this case.
 - Improved the length transition of the connector lines of the "Rainbow Labels" theme. 
 

--- a/src/common/item-types/command-item-action.ts
+++ b/src/common/item-types/command-item-action.ts
@@ -8,7 +8,7 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { exec } from 'child_process';
+import { spawn, StdioOptions } from 'child_process';
 import * as os from 'os';
 
 import { IMenuItem } from '../index';
@@ -31,12 +31,15 @@ export class CommandItemAction implements IItemAction {
   }
 
   /**
-   * Runs the command.
+   * Runs the command. It will asynchronously wait for one second to see if the command
+   * finishes with an non-zero exit code. If it does, the promise will be rejected. Else
+   * it will assume that the command was started successfully and resolve the promise. So
+   * if an error occurs after one second, it will not be detected.
    *
    * @param item The item for which the action should be executed.
    * @param backend The backend which is currently in use.
    * @param wmInfo Information about the window manager state when the menu was opened.
-   * @returns A promise which resolves when the command has been successfully executed.
+   * @returns A promise which resolves when the command has been successfully started.
    */
   async execute(item: DeepReadonly<IMenuItem>, backend: Backend, wmInfo: WMInfo) {
     return new Promise<void>((resolve, reject) => {
@@ -54,16 +57,48 @@ export class CommandItemAction implements IItemAction {
       const env = { ...process.env };
       delete env.CHROME_DESKTOP;
 
+      // We are only interested in a potential error output.
+      const stdio: StdioOptions = ['ignore', 'ignore', 'pipe'];
+
       const options = {
         env,
         cwd: os.homedir(),
+        shell: true,
+        detached: true,
+        stdio,
       };
 
-      exec(command, options, (error) => {
-        if (error) {
-          reject(error.message);
-        } else {
+      const child = spawn(command, [], options);
+
+      let resolved = false;
+      let errorOutput = '';
+
+      // We set a timeout of one second. If the process does not exit within this time,
+      // we assume that it was started successfully and resolve the promise.
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          child.unref();
           resolve();
+        }
+      }, 1000);
+
+      // We collect the error output of the process.
+      child.stderr.on('data', (data) => {
+        errorOutput += data.toString();
+      });
+
+      // If the process exits within the timeout, we either resolve or reject the promise
+      // based on the exit code.
+      child.on('exit', (code) => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          resolved = true;
+          if (code !== 0) {
+            reject(errorOutput);
+          } else {
+            resolve();
+          }
         }
       });
     });


### PR DESCRIPTION
This makes sure that processes launched with the command action are detached. This way, they are not killed if Kando exits.