### PR TITLE
Handle read-only config files neatly

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -527,6 +527,9 @@ export interface IAppSettings {
   /** Set this to false to disable the check for new versions. */
   enableVersionCheck: boolean;
 
+  /** Whether to silently handle read-only config files * */
+  ignoreWriteProtectedConfigFiles: boolean;
+
   /** Whether the sidebar should be shown in the editor. */
   sidebarVisible: boolean;
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -527,7 +527,7 @@ export interface IAppSettings {
   /** Set this to false to disable the check for new versions. */
   enableVersionCheck: boolean;
 
-  /** Whether to silently handle read-only config files * */
+  /** Whether to silently handle read-only config files. */
   ignoreWriteProtectedConfigFiles: boolean;
 
   /** Whether the sidebar should be shown in the editor. */

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -125,6 +125,7 @@ export class KandoApp {
         soundTheme: 'none',
         soundVolume: 0.5,
         sidebarVisible: true,
+        ignoreWriteProtectedConfigFiles: false,
         enableVersionCheck: true,
         zoomFactor: 1,
         menuOptions: {
@@ -193,6 +194,20 @@ export class KandoApp {
     // When the app settings change, we need to apply the zoom factor to the window.
     this.appSettings.onChange('zoomFactor', (newValue) => {
       this.window.webContents.setZoomFactor(newValue);
+    });
+
+    // Check if we want to silently handle read-only config files
+    this.appSettings.ignoreWriteProtectedConfigFiles = this.appSettings.get(
+      'ignoreWriteProtectedConfigFiles'
+    );
+    this.menuSettings.ignoreWriteProtectedConfigFiles = this.appSettings.get(
+      'ignoreWriteProtectedConfigFiles'
+    );
+
+    // When ignoreWriteProtectedConfigFiles becomes true we want to apply this immidiatly
+    this.appSettings.onChange('ignoreWriteProtectedConfigFiles', (newValue) => {
+      this.appSettings.ignoreWriteProtectedConfigFiles = newValue;
+      this.menuSettings.ignoreWriteProtectedConfigFiles = newValue;
     });
 
     // Initialize the IPC communication to the renderer process.

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -204,7 +204,7 @@ export class KandoApp {
       'ignoreWriteProtectedConfigFiles'
     );
 
-    // When ignoreWriteProtectedConfigFiles becomes true we want to apply this immidiatly
+    // When ignoreWriteProtectedConfigFiles becomes true we want to apply this immediately.
     this.appSettings.onChange('ignoreWriteProtectedConfigFiles', (newValue) => {
       this.appSettings.ignoreWriteProtectedConfigFiles = newValue;
       this.menuSettings.ignoreWriteProtectedConfigFiles = newValue;

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -138,6 +138,7 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
   /** This is the path to the settings file. */
   private readonly filePath: string;
 
+  /** If set to true, no notification will be shown when the JSON file cannot be written. */
   public ignoreWriteProtectedConfigFiles = false;
 
   /** This is the watcher which is used to watch the settings file for changes. */

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -299,10 +299,10 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
       // Handle read-only config files correctly.
       if (error.code === 'EROFS' || error.code === 'EACCES') {
         // Generate a temporary directory to write the files to for easy reference and write to it.
-        const tmpBaseDir = os.tmpdir() + '/kando/';
+        const tmpBaseDir = path.join(os.tmpdir(), 'kando');
         fs.mkdirSync(tmpBaseDir, { recursive: true });
         const baseName = path.basename(this.filePath);
-        const tmpDir = tmpBaseDir + baseName;
+        const tmpDir = path.join(tmpBaseDir, baseName);
         fs.writeJSONSync(tmpDir, updatedSettings, { spaces: 2 });
 
         // If the config option ignoreWriteProtectedConfigFiles is not set; notify the user that their hard work has not been permanently saved.
@@ -313,7 +313,7 @@ export class Settings<T extends object> extends PropertyChangeEmitter<T> {
             ' file was read-only. It will temporarily be saved to: ' +
             tmpDir +
             " Set ignoreWriteProtectedConfigFiles to 'true' to silence this warning";
-          console.log(errorMessage);
+          console.warn(errorMessage);
 
           if (Notification.isSupported()) {
             const notification = new Notification({


### PR DESCRIPTION
This PR causes Kando to correctly handle the situation where config files are read-only or the user has no permission to write to them.
When a config file is in such a state we log the error to stdout and send a notification to warn the user their work was not saved. We also save the new config to `os.tmpdir()/kando/{config.json, menus.json}` For easy reference (for example for inclusion into a nix configuration)
Finally it is also possible to set `ignoreWriteProtectedConfigFiles: true` in `config.json` to silence the notification and stdout warning (but still write to /tmp/kando)

fixes #740 