### PR TITLE
Use macos 13 for building and deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
     name: Deploy for macOS
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,7 @@ jobs:
     name: Test Deploy for macOS
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 - The app images for Linux now contain an SVG icon and appstream metadata.
 - Improved the vertical alignment of the text in the "Rainbow Labels" theme when using a zoom level other than 100%. Thanks to [@elfi-ox](https://github.com/elfi-ox) for finding this fix!
+- The x86_64 macOS build is now created on macOS 13.
 
 ## [Kando 1.6.0](https://github.com/kando-menu/kando/releases/tag/v1.6.0)
 


### PR DESCRIPTION
macOS 12 runners are now deprecated.