### PR TITLE
Add winget deploy workflow

### DIFF
--- a/.github/workflows/deploy_to_winget.yml
+++ b/.github/workflows/deploy_to_winget.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+# SPDX-License-Identifier: CC0-1.0
+
+name: Deploy to Winget
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.2
+        with:
+          regex: true
+          file: 'Kando-.*\.exe'
+      - name: Publish to Winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: KandoMenu.Kando
+          installers-regex: 'Kando-.*\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This adds a workflow which should update the [Kando manifest](https://github.com/microsoft/winget-pkgs/tree/master/manifests/k/KandoMenu/Kando/1.7.0) of winget after an release.

If this really works, we will see after the next release 😄 