### PR TITLE
Fix simulating numpad subtract

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 #### :bug: Fixed
 
 - A bug which caused a black menu background on Linux when auto-starting Kando on login. The solution involves that the menu window is now initialized lazily. This means, that the first time a menu is opened, it may take a little longer to appear. But this should only happen once per session.
+- Simulating <kbd>Numpad Subtract</kbd> on Windows.
 
 ## [Kando 1.7.0](https://github.com/kando-menu/kando/releases/tag/v1.7.0)
 

--- a/src/common/key-codes.ts
+++ b/src/common/key-codes.ts
@@ -1366,7 +1366,7 @@ const KEY_CODES: Map<string, IKeyMapping> = new Map([
   [
     'numpadsubtract',
     {
-      windows: null,
+      windows: 0x004a,
       macos: 0x4e,
       linux: 0x0052,
     },


### PR DESCRIPTION
This adds a missing key code for <kbd>Numpad Subtract</kbd> on Windows.