### PR TITLE
Add new file item type

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### :tada: Added
 
+- **A new item type: Open File!** Use this to open files or directories with the default application. You could do this with the Command or Open URI item types before, but this new item type is more intuitive. Also, the Open URI type had issues with non-ASCII characters in the file path, which should be fixed with this new item type.
 - **Experimental support arm64 on Linux!** There is now an experimental arm64 build for Linux. Please test it and report any issues you encounter!
 - **Two new tray icon flavors!** There is now also a `'white'` and a `'black'` flavor. You can choose them in your `config.json` using the `trayIconFlavor` property. The default is still `'color'`. Thanks to [@kartik-raj7](https://github.com/kartik-raj7) for the contribution!
 - **The possibility to temporarily disable all shortcuts** by using the tray icon context menu. Thanks to [@yar2000T](https://github.com/yar2000T) for contributing this feature!

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -16,6 +16,13 @@
       "delayed-option-hint": "Useful if the action targets a window that needs to be focused.",
       "not-configured": "Not configured"
     },
+    "file": {
+      "tip-1": "You can use this item type to open files or folders.",
+      "file": "File Path",
+      "file-hint": "This will be opened.",
+      "name": "Open File",
+      "description": "Opens a file or folder."
+    },
     "hotkey": {
       "tip-1": "When recording a hotkey, you do not have to press all keys at once. You can press them one after another.",
       "tip-2": "If you cannot record a key because it is used by the system, try typing its name directly.",
@@ -54,7 +61,7 @@
     },
     "uri": {
       "tip-1": "You can use the URI item type to open a website using the http:// protocol.",
-      "tip-2": "You can use the URI item type to open a file or folder using the file:// protocol.",
+      "tip-2": "You can use this to call custom URI schemes like slack:// or zoommtg://.",
       "tip-3": "You can use the URI item type to open a mailto: link.",
       "tip-4": "Use {{app_name}} to insert the name of the application which was focused when you opened the menu.",
       "tip-5": "Use {{window_name}} to insert the name of the window which was focused when you opened the menu.",
@@ -62,7 +69,7 @@
       "uri": "URI",
       "uri-hint": "This will be opened.",
       "name": "Open URI",
-      "description": "Opens files or websites."
+      "description": "Opens websites and more."
     }
   },
   "main": {

--- a/src/common/item-action-registry.ts
+++ b/src/common/item-action-registry.ts
@@ -12,6 +12,7 @@ import { IMenuItem } from './index';
 import { Backend, WMInfo } from '../main/backends/backend';
 
 import { CommandItemAction } from './item-types/command-item-action';
+import { FileItemAction } from './item-types/file-item-action';
 import { HotkeyItemAction } from './item-types/hotkey-item-action';
 import { MacroItemAction } from './item-types/macro-item-action';
 import { TextItemAction } from './item-types/text-item-action';
@@ -68,6 +69,7 @@ export class ItemActionRegistry {
    */
   private constructor() {
     this.actions.set('command', new CommandItemAction());
+    this.actions.set('file', new FileItemAction());
     this.actions.set('hotkey', new HotkeyItemAction());
     this.actions.set('macro', new MacroItemAction());
     this.actions.set('text', new TextItemAction());

--- a/src/common/item-config-registry.ts
+++ b/src/common/item-config-registry.ts
@@ -11,6 +11,7 @@
 import { IMenuItem } from '.';
 import { SubmenuItemConfig } from './item-types/submenu-item-config';
 import { CommandItemConfig } from './item-types/command-item-config';
+import { FileItemConfig } from './item-types/file-item-config';
 import { HotkeyItemConfig } from './item-types/hotkey-item-config';
 import { MacroItemConfig } from './item-types/macro-item-config';
 import { TextItemConfig } from './item-types/text-item-config';
@@ -57,6 +58,7 @@ export class ItemConfigRegistry {
    */
   private constructor() {
     this.configs.set('command', new CommandItemConfig());
+    this.configs.set('file', new FileItemConfig());
     this.configs.set('hotkey', new HotkeyItemConfig());
     this.configs.set('macro', new MacroItemConfig());
     this.configs.set('submenu', new SubmenuItemConfig());

--- a/src/common/item-type-registry.ts
+++ b/src/common/item-type-registry.ts
@@ -11,6 +11,7 @@
 import { IMenuItem } from './index';
 
 import { CommandItemType } from './item-types/command-item-type';
+import { FileItemType } from './item-types/file-item-type';
 import { HotkeyItemType } from './item-types/hotkey-item-type';
 import { MacroItemType } from './item-types/macro-item-type';
 import { SubmenuItemType } from './item-types/submenu-item-type';
@@ -72,6 +73,7 @@ export class ItemTypeRegistry {
    */
   private constructor() {
     this.types.set('command', new CommandItemType());
+    this.types.set('file', new FileItemType());
     this.types.set('hotkey', new HotkeyItemType());
     this.types.set('macro', new MacroItemType());
     this.types.set('submenu', new SubmenuItemType());

--- a/src/common/item-types/file-item-action.ts
+++ b/src/common/item-types/file-item-action.ts
@@ -1,0 +1,38 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { IMenuItem } from '../index';
+import { IItemAction } from '../item-action-registry';
+import { DeepReadonly } from '../../main/settings';
+import { IItemData } from './file-item-type';
+import { shell } from 'electron';
+
+/** This action opens files with the default application. */
+export class FileItemAction implements IItemAction {
+  /**
+   * Files are opened immediately.
+   *
+   * @returns False
+   */
+  delayedExecution() {
+    return false;
+  }
+
+  /**
+   * Opens a file with the default application.
+   *
+   * @param item The item for which the action should be executed.
+   * @returns A promise which resolves when the file has been opened.
+   */
+  async execute(item: DeepReadonly<IMenuItem>) {
+    await shell.openPath((item.data as IItemData).path);
+    return;
+  }
+}

--- a/src/common/item-types/file-item-config.ts
+++ b/src/common/item-types/file-item-config.ts
@@ -1,0 +1,48 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import i18next from 'i18next';
+
+import { IMenuItem } from '..';
+import { IItemConfig } from '../item-config-registry';
+import { IItemData } from './file-item-type';
+import * as utils from './utils';
+
+/** This class provides the configuration widgets for file items. */
+export class FileItemConfig implements IItemConfig {
+  /** @inheritdoc */
+  public getTipOfTheDay(): string {
+    const tips = [i18next.t('items.file.tip-1')];
+
+    return tips[Math.floor(Math.random() * tips.length)];
+  }
+
+  /** @inheritdoc */
+  public getConfigWidget(item: IMenuItem): DocumentFragment | null {
+    const fragment = utils.renderTemplate(
+      require('../../renderer/editor/properties/templates/text-option.hbs'),
+      {
+        placeholder: i18next.t('items.common.not-configured'),
+        label: i18next.t('items.file.file'),
+      }
+    );
+
+    // Get the input element and set the current value.
+    const input = fragment.querySelector('input');
+    input.value = (item.data as IItemData).path || '';
+
+    // Listen for changes and update the item.
+    input.addEventListener('input', () => {
+      (item.data as IItemData).path = input.value;
+    });
+
+    return fragment;
+  }
+}

--- a/src/common/item-types/file-item-config.ts
+++ b/src/common/item-types/file-item-config.ts
@@ -31,6 +31,7 @@ export class FileItemConfig implements IItemConfig {
       {
         placeholder: i18next.t('items.common.not-configured'),
         label: i18next.t('items.file.file'),
+        hint: i18next.t('items.file.file-hint'),
       }
     );
 

--- a/src/common/item-types/file-item-type.ts
+++ b/src/common/item-types/file-item-type.ts
@@ -1,0 +1,55 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import i18next from 'i18next';
+
+import { IMenuItem } from '../index';
+import { IItemType } from '../item-type-registry';
+
+/**
+ * For this type of menu items, the user can configure a path that will be opened when the
+ * item is clicked.
+ */
+export interface IItemData {
+  path: string;
+}
+
+/** This class provides meta information for menu items that open a file. */
+export class FileItemType implements IItemType {
+  get hasChildren(): boolean {
+    return false;
+  }
+
+  get defaultName(): string {
+    return i18next.t('items.file.name');
+  }
+
+  get defaultIcon(): string {
+    return 'folder_open';
+  }
+
+  get defaultIconTheme(): string {
+    return 'material-symbols-rounded';
+  }
+
+  get defaultData(): IItemData {
+    return {
+      path: '',
+    };
+  }
+
+  get genericDescription(): string {
+    return i18next.t('items.file.description');
+  }
+
+  getDescription(item: IMenuItem): string {
+    return (item.data as IItemData).path || i18next.t('items.common.not-configured');
+  }
+}


### PR DESCRIPTION
You can use this new item type to open files or directories with the default application. You could do this with the Command or Open URI item types before, but this new item type is more intuitive. Also, the Open URI type had issues with non-ASCII characters in the file path, which should be fixed with this new item type (#798).