### PR TITLE
Add hover mode

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### :tada: Added
 
+- **A new way of interaction: Hover Mode!** This is for power users only: It's like turbo mode, but you don't have to press any keys. Just move the mouse to the item you want to select and wait a fraction of a second. This is by far the fastest way to navigate through your menus, but it can also lead to accidental selections as there is no way to visually confirm the selection before it happens. You can enable this in the settings under "Menu Behavior". Have fun blasting through your menus!
 - **A new item type: Open File!** Use this to open files or directories with the default application. You could do this with the Command or Open URI item types before, but this new item type is more intuitive. Also, the Open URI type had issues with non-ASCII characters in the file path, which should be fixed with this new item type.
 - **A new item type: Redirect!** Use this to open a different menu when the item is selected. Thanks to [@yar2000T](https://github.com/yar2000T) for contributing this feature!
 - **Experimental support arm64 on Linux!** There is now an experimental arm64 build for Linux. Please test it and report any issues you encounter!

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -101,6 +101,8 @@
     "advanced-options": {
       "heading": "Tweak the Menu's Behavior",
       "subheading": "Before you enable these options, we recommend learning Kando's default behavior. Read about why we like it <a {{- link}}>here</a>.",
+      "hover-mode": "Hover Mode",
+      "hover-mode-hint": "For power users only! Select items by hovering over them.",
       "centered-mode": "Centered Mode",
       "centered-mode-hint": "Open the menu in the screen's center instead of at the cursor.",
       "warp-mouse": "Warp Mouse in Centered Mode",

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -381,6 +381,12 @@ export interface IMenu {
   anchored: boolean;
 
   /**
+   * If true, the menu will be in "hover mode". This means that the menu items can be
+   * selected by only hovering over them.
+   */
+  hoverMode: boolean;
+
+  /**
    * Conditions are matched before showing a menu. The one that has more conditions and
    * met them all is selected.
    */
@@ -401,6 +407,7 @@ export function deepCopyMenu(menu: IMenu): IMenu {
     centered: menu.centered,
     warpMouse: menu.warpMouse,
     anchored: menu.anchored,
+    hoverMode: menu.hoverMode,
     conditions: structuredClone(menu.conditions),
   };
 }
@@ -446,6 +453,12 @@ export interface IShowMenuOptions {
    * opened at the same position as the parent menu.
    */
   anchoredMode: boolean;
+
+  /**
+   * If this is set, the menu will be in "hover mode". This means that the menu items can
+   * be selected by only hovering over them.
+   */
+  hoverMode: boolean;
 }
 
 /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -552,6 +552,7 @@ export class KandoApp {
             centeredMode: this.lastMenu.centered,
             anchoredMode: this.lastMenu.anchored,
             warpMouse: this.lastMenu.warpMouse,
+            hoverMode: this.lastMenu.hoverMode,
           },
           {
             appName: info.appName,

--- a/src/renderer/editor/properties/advanced-options-picker.ts
+++ b/src/renderer/editor/properties/advanced-options-picker.ts
@@ -37,6 +37,12 @@ export class AdvancedOptionsPicker extends EventEmitter {
   private anchoredModeCheckbox: HTMLInputElement = null;
 
   /**
+   * The hover mode checkbox is a checkbox that allows the user to toggle whether menu
+   * items should be activated on hover.
+   */
+  private hoverModeCheckbox: HTMLInputElement = null;
+
+  /**
    * The warp mouse checkbox is a checkbox that allows the user to toggle whether the
    * mouse should be warped to the center of the menu when it is opened.
    */
@@ -63,6 +69,8 @@ export class AdvancedOptionsPicker extends EventEmitter {
         subheading: i18next.t('properties.advanced-options.subheading', {
           link: 'target="_blank" href="https://kando.menu/usage/"',
         }),
+        hoverMode: i18next.t('properties.advanced-options.hover-mode'),
+        hoverModeHint: i18next.t('properties.advanced-options.hover-mode-hint'),
         centeredMode: i18next.t('properties.advanced-options.centered-mode'),
         centeredModeHint: i18next.t('properties.advanced-options.centered-mode-hint'),
         warpMouse: i18next.t('properties.advanced-options.warp-mouse'),
@@ -106,6 +114,16 @@ export class AdvancedOptionsPicker extends EventEmitter {
       }
     });
 
+    // Update the hover-mode property of the menu when the checkbox changes.
+    this.hoverModeCheckbox = container.querySelector(
+      '#kando-menu-properties-hover-mode'
+    ) as HTMLInputElement;
+    this.hoverModeCheckbox.addEventListener('change', () => {
+      if (this.menu) {
+        this.menu.hoverMode = this.hoverModeCheckbox.checked;
+      }
+    });
+
     // Close the picker when the user clicks the Cancel button.
     const doneButton = container.querySelector(
       '#kando-properties-advanced-options-picker-close'
@@ -132,5 +150,6 @@ export class AdvancedOptionsPicker extends EventEmitter {
     this.centeredModeCheckbox.checked = menu.centered;
     this.warpMouseCheckbox.checked = menu.warpMouse;
     this.anchoredModeCheckbox.checked = menu.anchored;
+    this.hoverModeCheckbox.checked = menu.hoverMode;
   }
 }

--- a/src/renderer/editor/properties/templates/advanced-options-picker.hbs
+++ b/src/renderer/editor/properties/templates/advanced-options-picker.hbs
@@ -31,6 +31,13 @@
     id="kando-menu-properties-anchored-mode"
 }}
 
+{{> checkbox-option 
+    label=strings/hoverMode
+    hint=strings/hoverModeHint
+    checkedHint=strings/hoverModeCheckedHint
+    id="kando-menu-properties-hover-mode"
+}}
+
 <div class='d-flex justify-content-end mt-3'>
   <button class="btn btn-secondary fs-3 kando-font my-3 px-5 ms-auto" id="kando-properties-advanced-options-picker-close">{{strings/done}}</button>
 </div>

--- a/src/renderer/menu/menu.ts
+++ b/src/renderer/menu/menu.ts
@@ -248,6 +248,9 @@ export class Menu extends EventEmitter {
     this.pointerInput.enableTurboMode =
       this.options.enableTurboMode && !showMenuOptions.anchoredMode;
 
+    // Enable hover mode if configured for the menu.
+    this.pointerInput.enableHoverMode = showMenuOptions.hoverMode;
+
     this.root = root;
     this.setupPaths(this.root);
     this.setupAngles(this.root);


### PR DESCRIPTION
This adds a very advanced interaction mode: **Hover Mode**! This is like turbo mode or marking mode, but without the need to press any key or button! This is very advanced as it can easily lead to wrong selections. But at the same time, it is the fastest selection mode available!

This fixes #303.