### PR TITLE
Add optional confirmation click to hover mode

### DIFF
--- a/assets/menu-themes/clean-circle/theme.css
+++ b/assets/menu-themes/clean-circle/theme.css
@@ -133,9 +133,13 @@
   }
 
 
-  &.active:has(.hovered:not(.dragged.type-submenu))>.arrow-layer {
+  &.active:has(.hovered)>.arrow-layer {
     transform: rotate(var(--hovered-child-angle)) translateY(calc(-0.5 * var(--center-size) - 5px + 1px));
     opacity: 1;
+  }
+
+  &.active:has(.clicked)>.arrow-layer {
+    transform: rotate(var(--pointer-angle)) translateY(calc(-0.5 * var(--center-size) - 5px + 1px));
   }
 
   /* If the parent or a child node is clicked, we scale it down to normal size. */
@@ -193,13 +197,13 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   }
 
-  &:has(>.dragged)>.connector,
-  &:has(>.clicked)>.connector {
+  &:has(>.dragged)>.connector {
     transition: none;
   }
 
   &:has(>.parent)>.connector,
   &:has(>.active.type-submenu)>.connector,
+  &:has(>.clicked.type-submenu)>.connector,
   &:has(>.dragged.type-submenu)>.connector {
     opacity: 1;
   }

--- a/assets/menu-themes/default/theme.css
+++ b/assets/menu-themes/default/theme.css
@@ -154,8 +154,7 @@
     top: calc(-1 * var(--connector-width) / 2);
   }
 
-  &:has(.dragged)>.connector,
-  &:has(.clicked)>.connector {
+  &:has(.dragged)>.connector {
     transition: none;
   }
 

--- a/assets/menu-themes/neon-lights/theme.css
+++ b/assets/menu-themes/neon-lights/theme.css
@@ -249,8 +249,7 @@
     top: calc(-1 * var(--connector-width) / 2);
   }
 
-  &:has(.dragged)>.connector,
-  &:has(.clicked)>.connector {
+  &:has(.dragged)>.connector {
     transition: none;
   }
 

--- a/assets/menu-themes/rainbow-labels/theme.css
+++ b/assets/menu-themes/rainbow-labels/theme.css
@@ -166,13 +166,13 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   }
 
-  &:has(>.dragged)>.connector,
-  &:has(>.clicked)>.connector {
+  &:has(>.dragged)>.connector {
     transition: none;
   }
 
   &:has(>.parent)>.connector,
   &:has(>.active.type-submenu)>.connector,
+  &:has(>.clicked.type-submenu)>.connector,
   &:has(>.dragged.type-submenu)>.connector {
     opacity: 1;
   }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### :tada: Added
 
-- **A new way of interaction: Hover Mode!** This is for power users only: It's like turbo mode, but you don't have to press any keys. Just move the mouse to the item you want to select and wait a fraction of a second. This is by far the fastest way to navigate through your menus, but it can also lead to accidental selections as there is no way to visually confirm the selection before it happens. You can enable this in the settings under "Menu Behavior". Have fun blasting through your menus!
+- **A new way of interaction: Hover Mode!** This is for power users only: It's like turbo mode, but you don't have to press any keys. Just move the mouse to the item you want to select and wait a fraction of a second. This is by far the fastest way to navigate through your menus, but it can also lead to accidental selections as there is no way to visually confirm the selection before it happens. You can enable this in the settings under "Menu Behavior". You can set `"menuOptions": {"hoverModeNeedsConfirmation": true}` in your `config.json` to tweak the hover mode so that it requires a final click to select an item. This is a bit slower, but it can prevent accidental selections.
 - **A new item type: Open File!** Use this to open files or directories with the default application. You could do this with the Command or Open URI item types before, but this new item type is more intuitive. Also, the Open URI type had issues with non-ASCII characters in the file path, which should be fixed with this new item type.
 - **A new item type: Redirect!** Use this to open a different menu when the item is selected. Thanks to [@yar2000T](https://github.com/yar2000T) for contributing this feature!
 - **Experimental support arm64 on Linux!** There is now an experimental arm64 build for Linux. Please test it and report any issues you encounter!
@@ -32,6 +32,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 #### :wrench: Changed
 
+- Menu items will now move to the mouse pointer on pointer-down events instead of pointer-up events. This makes the menu feel more responsive.
 - The Windows installer now shows a custom gif animation instead of the default Squirrel animation.
 - The Windows installer now uses the new Kando icon instead of the default Electron icon.
 - On Windows, Kando will now also show a custom icon in the Control Panel > Programs and Features section. Before, the Electron icon was shown there.

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -150,6 +150,7 @@ export class KandoApp {
           fadeOutDuration: 200,
           enableMarkingMode: true,
           enableTurboMode: true,
+          hoverModeNeedsConfirmation: false,
           gestureMinStrokeLength: 150,
           gestureMinStrokeAngle: 20,
           gestureJitterThreshold: 10,

--- a/src/renderer/menu/input-methods/pointer-input.ts
+++ b/src/renderer/menu/input-methods/pointer-input.ts
@@ -44,6 +44,9 @@ export class PointerInput extends InputMethod {
    */
   public enableHoverMode = true;
 
+  /** If set to true, the hover mode will only select final actions with a mouse click. */
+  public hoverModeNeedsConfirmation = false;
+
   /**
    * This is used to detect gestures in "Marking Mode" and "Turbo Mode". It is fed with
    * motion events and emits a selection event if either the mouse pointer was stationary
@@ -98,7 +101,9 @@ export class PointerInput extends InputMethod {
     this.gestureDetector.on('selection', (position: IVec2) => {
       this.selectCallback(
         position,
-        this.enableHoverMode ? SelectionType.eActiveItem : SelectionType.eSubmenuOnly
+        this.enableHoverMode && !this.hoverModeNeedsConfirmation
+          ? SelectionType.eActiveItem
+          : SelectionType.eSubmenuOnly
       );
     });
   }


### PR DESCRIPTION
You can now set `"menuOptions": {"hoverModeNeedsConfirmation": true}` in your `config.json` to tweak the hover mode so that it requires a final click to select an item. This is a bit slower, but it can prevent accidental selections.