### PR TITLE
Mention URL support in base64 picker

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -113,7 +113,7 @@ const config: ForgeConfig = {
       devContentSecurityPolicy:
         "default-src 'self' 'unsafe-inline' data:; " +
         "script-src 'self' 'unsafe-eval' 'unsafe-inline' data:; " +
-        "img-src 'self' file: data:; " +
+        "img-src 'self' file: data: https:; " +
         "font-src 'self' file: data:; " +
         "style-src-elem 'self' 'unsafe-inline' file: data:; " +
         "media-src 'self' file: data:; " +

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -141,6 +141,8 @@
     "icon-picker": {
       "heading": "Select an Icon",
       "subheading": "Add your own icon collections by putting a folder with images into {{path}}. You will need to restart Kando. Learn more <a {{- link}}>here</a>.",
+      "base64-example": "Base64 example:",
+      "url-example": "URL example:",
       "placeholder": "Search Icons…"
     },
     "macro-picker": {

--- a/src/renderer/icon-themes/base64-theme.ts
+++ b/src/renderer/icon-themes/base64-theme.ts
@@ -18,7 +18,7 @@ import { Base64Picker } from './icon-pickers/base64-picker';
 export class Base64Theme implements IIconTheme {
   /** Returns a human-readable name of the icon theme. */
   get name() {
-    return 'Base64 or URL';
+    return 'Base64 / URL';
   }
 
   /**

--- a/src/renderer/icon-themes/base64-theme.ts
+++ b/src/renderer/icon-themes/base64-theme.ts
@@ -13,18 +13,19 @@ import { Base64Picker } from './icon-pickers/base64-picker';
 
 /**
  * This class implements an icon theme that allows the user to enter base64 encoded images
- * directly.
+ * or URLs directly.
  */
 export class Base64Theme implements IIconTheme {
   /** Returns a human-readable name of the icon theme. */
   get name() {
-    return 'Base64';
+    return 'Base64 or URL';
   }
 
   /**
-   * Creates a div element that contains the icon with the given base64 encoded image.
+   * Creates a div element that contains the icon with the given base64 encoded image or
+   * URL.
    *
-   * @param icon The base64 encoded image.
+   * @param icon The base64 encoded image or URL.
    * @returns A div element that contains the icon.
    */
   createIcon(icon: string) {

--- a/src/renderer/icon-themes/icon-pickers/base64-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/base64-picker.ts
@@ -8,6 +8,8 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
+import i18next from 'i18next';
+
 import { IIconPicker } from '../icon-theme-registry';
 
 /**
@@ -30,10 +32,10 @@ export class Base64Picker implements IIconPicker {
 
     this.textArea = document.createElement('textarea');
     this.textArea.placeholder = [
-      'Base64 example:',
+      i18next.t('properties.icon-picker.base64-example'),
       'data:image/svg;base64,...',
       '',
-      'URL example:',
+      i18next.t('properties.icon-picker.url-example'),
       'https://cdn.simpleicons.org/simpleicons/white',
     ].join('\n');
     this.textArea.classList.add('base64-picker');

--- a/src/renderer/icon-themes/icon-pickers/base64-picker.ts
+++ b/src/renderer/icon-themes/icon-pickers/base64-picker.ts
@@ -11,17 +11,17 @@
 import { IIconPicker } from '../icon-theme-registry';
 
 /**
- * An icon picker which is only a text area. The user can enter a base64 encoded image
- * directly.
+ * An icon picker which is only a text area. The user can enter a base64 encoded image or
+ * URL directly.
  */
 export class Base64Picker implements IIconPicker {
   /** The container to which the icon picker is appended. */
   private fragment: DocumentFragment = null;
 
-  /** The textarea where the user can enter a base64 encoded image. */
+  /** The textarea where the user can enter a base64 encoded image or URL. */
   private textArea: HTMLTextAreaElement = null;
 
-  /** This callback is called when the user enters a valid base64 encoded image. */
+  /** This callback is called when the user enters a valid base64 encoded image or URL. */
   private onSelectCallback: (icon: string) => void = null;
 
   /** Creates a new IconPicker and appends it to the given container. */
@@ -29,7 +29,13 @@ export class Base64Picker implements IIconPicker {
     this.fragment = document.createDocumentFragment();
 
     this.textArea = document.createElement('textarea');
-    this.textArea.placeholder = 'data:image/svg;base64,...';
+    this.textArea.placeholder = [
+      'Base64 example:',
+      'data:image/svg;base64,...',
+      '',
+      'URL example:',
+      'https://cdn.simpleicons.org/simpleicons/white',
+    ].join('\n');
     this.textArea.classList.add('base64-picker');
     this.textArea.classList.add('form-control');
     this.textArea.classList.add('my-3');


### PR DESCRIPTION
### Changes

- Update `forge.config.ts` configuration to unblock `https:` resources during development
- Rename `Base64` option to `Base64 or URL`
- Mention URL support in Base64 picker's placeholder
- Update code comments: `Base64 images` -> `Base64 images or URLs`