### PR TITLE
Fix input size of icon picker

### DIFF
--- a/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
+++ b/src/renderer/icon-themes/icon-pickers/templates/icon-list-picker.hbs
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 }}
 
-<input type="text" class="icon-list-picker-filter fs-3 kando-font form-control flex-grow-1 mt-3" placeholder="{{strings/placeholder}}" />
+<input type="text" class="icon-list-picker-filter fs-3 kando-font form-control mt-3" placeholder="{{strings/placeholder}}" />
 
 <div class='scrollbox mx-2'>
   <div class="scrollbox-content">


### PR DESCRIPTION
Fixed an unexpected input size change.

|Before|After|
|:-:|:-:|
|![](https://github.com/user-attachments/assets/e90b5046-5fc5-4c83-8482-82f3be85d918)|![](https://github.com/user-attachments/assets/d013fd7b-b69a-4bc9-8286-c95b8c11c238)|

