### PR TITLE
🎉 Add default settings hotkey support for settings window (#470).

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -691,6 +691,12 @@ export interface IAppSettings {
    * https://w3c.github.io/gamepad/#remapping for the mapping of numbers to buttons.
    */
   gamepadCloseButton: number;
+
+  /**
+   * If enabled, pressing 'cmd + ,' on macOS or 'ctrl + ,' on Linux or Windows will open
+   * the settings window. If disabled, the default hotkey will be ignored.
+   */
+  useDefaultOsShowSettingsHotkey: boolean;
 }
 
 /**
@@ -731,6 +737,7 @@ export function getDefaultAppSettings(): IAppSettings {
     enableGamepad: true,
     gamepadBackButton: 1,
     gamepadCloseButton: 2,
+    useDefaultOsShowSettingsHotkey: true,
     hideSettingsButton: false,
     settingsButtonPosition: 'bottom-right',
   };

--- a/src/menu-renderer/index.ts
+++ b/src/menu-renderer/index.ts
@@ -151,11 +151,11 @@ Promise.all([
       window.menuAPI.cancelSelection();
     }
 
-    if ((await window.commonAPI.appSettings.get()).useDefaultOsShowSettingsHotkey) {
-      // Show the settings window if 'cmd + ,' hotkey is pressed on macOS
-      // or 'ctrl + ,' is pressed on non macOS systems.
-      const keyIsComma = ev.key === ',';
-      if ((ev.metaKey && keyIsComma && cIsMac) || (ev.ctrlKey && keyIsComma && !cIsMac)) {
+    // Show the settings window if 'cmd + ,' hotkey is pressed on macOS
+    // or 'ctrl + ,' is pressed on non macOS systems.
+    const keyIsComma = ev.key === ',';
+    if ((ev.metaKey && keyIsComma && cIsMac) || (ev.ctrlKey && keyIsComma && !cIsMac)) {
+      if ((await window.commonAPI.appSettings.get()).useDefaultOsShowSettingsHotkey) {
         showSettings();
       }
     }

--- a/src/menu-renderer/index.ts
+++ b/src/menu-renderer/index.ts
@@ -66,12 +66,18 @@ Promise.all([
     settings
   );
 
-  // Show the settings dialog when the button is clicked.
-  settingsButton.on('click', () => {
+  // Helper function to group and re-use function calls
+  // associated with showing the settings window.
+  const showSettings = () => {
     menu.hide();
     settingsButton.hide();
     window.menuAPI.cancelSelection();
     window.menuAPI.showSettings();
+  };
+
+  // Show the settings dialog when the button is clicked.
+  settingsButton.on('click', () => {
+    showSettings();
   });
 
   // Now, we create the menu. It will be responsible for drawing the menu and handling
@@ -137,12 +143,21 @@ Promise.all([
   // Report unhover events to the main process.
   menu.on('unhover', (path) => window.menuAPI.unhoverItem(path));
 
-  // Hide the menu when the user presses escape.
-  document.body.addEventListener('keydown', (ev) => {
+  document.body.addEventListener('keydown', async (ev) => {
+    // Hide the menu when the user presses escape.
     if (ev.key === 'Escape') {
       menu.hide();
       settingsButton.hide();
       window.menuAPI.cancelSelection();
+    }
+
+    if ((await window.commonAPI.appSettings.get()).useDefaultOsShowSettingsHotkey) {
+      // Show the settings window if 'cmd + ,' hotkey is pressed on macOS
+      // or 'ctrl + ,' is pressed on non macOS systems.
+      const keyIsComma = ev.key === ',';
+      if ((ev.metaKey && keyIsComma && cIsMac) || (ev.ctrlKey && keyIsComma && !cIsMac)) {
+        showSettings();
+      }
     }
   });
 


### PR DESCRIPTION
# Changes
- Add support for default 'open settings' OS dependent hotkeys.
- Add setting to enable or disable the previously mentioned hotkeys.
- Move `getBackendInfo` function to the common API and refactor where necessary.