### PR TITLE
Add support for deep links

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 ### :tada: Added
 
+- **Support for deep links!** You can now use the `kando://` protocol to open Kando menus from other applications. This supports all command line parameters. For instance, `kando://menu?name=<menu-name>` will open the menu with the given name. Or `kando://settings` will open the settings dialog. On Linux, this only works if Kando has been properly installed with a `.desktop` file. Thanks to [@LitoMore](https://github.com/LitoMore) for this contribution!
 - **Experimental support arm64 on Windows!** There is now an experimental arm64 build for Windows. Please test it and report any issues you encounter!
 - **A new menu item type: Open Settings!** This allows you to open the Kando settings directly from a menu item. Thanks to [@jonthemonke](https://github.com/jonthemonke) for this contribution!
 - A hotkey for opening the settings dialog when a menu is open. On macOS, this is <kbd>Command</kbd>+<kbd>,</kbd>. On Windows and Linux, it is <kbd>Ctrl</kbd>+<kbd>,</kbd>. Thanks to [@jonthemonke](https://github.com/jonthemonke) for this contribution!

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -101,6 +101,14 @@ const config: ForgeConfig = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       LSUIElement: true,
     },
+
+    // This is used to set the app name in the menu bar on macOS.
+    protocols: [
+      {
+        name: 'Kando',
+        schemes: ['kando'],
+      },
+    ],
   },
   rebuildConfig: {},
   makers: [makerSquirrel, makerZIP, makerDMG, makerDeb, makerRPM],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,6 +89,18 @@ app.setPath('sessionData', path.join(app.getPath('sessionData'), 'session'));
 app.setPath('crashDumps', path.join(app.getPath('sessionData'), 'crashDumps'));
 app.setAppLogsPath(path.join(app.getPath('sessionData'), 'logs'));
 
+// Set deep link support for the app. This is used to open the app with a specific menu when
+// the app is already running. The URL scheme is "kando://menus?menuName=<menuName>".
+if (process.defaultApp) {
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('kando', process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
+  }
+} else {
+  app.setAsDefaultProtocolClient('kando');
+}
+
 // Create the app and initialize it as soon as electron is ready.
 const kando = new KandoApp();
 
@@ -150,6 +162,17 @@ app
       // If no option was passed, we show the settings.
       if (!handleCommandLine(options)) {
         kando.showSettings();
+      }
+    });
+
+    // Handle the case when the app is opened via a deep link. This is used to open the menu.
+    app.on('open-url', (e, url) => {
+      const parseUrl = new URL(url);
+      if (parseUrl.host === 'open-menu') {
+        const name = parseUrl.searchParams.get('name');
+        if (name) {
+          kando.showMenu({ name });
+        }
       }
     });
 


### PR DESCRIPTION
This is a draft PR for showing how to implement the [deep link](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app) support. The deep link will be:

```
kando://menu?name=Example%20Menu
```

Putting the menu name parameter in the search parameter is better for parsing special cases like CJK characters and emojis.

@Schneegans I'm not sure my code was added to the correct place. And it should also have more validation before calling the `kando.showMenu()`, e.g., checking the existence of the menu name. Do you have any suggestions?
