### PR TITLE
Fix Simple Icons regex pattern

### DIFF
--- a/src/common/icon-themes/simple-icons-theme.ts
+++ b/src/common/icon-themes/simple-icons-theme.ts
@@ -25,7 +25,7 @@ export class SimpleIconsTheme implements IIconTheme {
     // Use regex to extract all icon names. In the file above, all the names start with a
     // '.si-' and end before the next '::before'. We also ensure not to match the variants
     // with the '--color' suffix.
-    const regex = /\.si-([a-z0-9-]+(?<!-color))(?=::before)/g;
+    const regex = /\.si-([a-z0-9-_]+(?<!-color))(?=::before)/g;
     let match;
 
     while ((match = regex.exec(string)) !== null) {


### PR DESCRIPTION
The icon slug may have the underscore character, like the Uniqlo (JP) icon:

![](https://github.com/user-attachments/assets/b92ad391-82c9-44cc-a671-a752a27dfaed)

You can try searching `uniqlo`; it should list two Uniqlo icons.