### PR TITLE
:bug: Fix icon size

### DIFF
--- a/src/settings-renderer/components/menu-properties/Properties.module.scss
+++ b/src/settings-renderer/components/menu-properties/Properties.module.scss
@@ -30,10 +30,9 @@
 .icon {
   -webkit-app-region: no-drag;
 
-  // Why have width and height have to be set to different values?
-  // Otherwise the icon is not circular...
   width: 6em;
-  height: 7.2em;
+  height: 6em;
+  flex-shrink: 0;
   margin: -30px auto 0 auto;
   background-color: $window-background;
   border-radius: 50%;


### PR DESCRIPTION
I just used a `flex-shrink: 0` to fix the sizing issue.

|Before|After|
|:-:|:-:|
|![](https://github.com/user-attachments/assets/83803afd-50e5-486d-894a-47d9a6cf2a16)|![](https://github.com/user-attachments/assets/e007a300-4684-4758-9eee-7a666731329d)|