### PR TITLE
:wrench: Fix tooltip content for Simple Icons Theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kando",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kando",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -81,7 +81,7 @@
         "react-window": "^1.8.11",
         "sass": "^1.89.0",
         "sass-loader": "^16.0.5",
-        "simple-icons-font": "^14.14.0",
+        "simple-icons-font": "^15.0.0",
         "string-replace-loader": "^3.1.0",
         "style-loader": "^4.0.0",
         "swiper": "^11.2.8",
@@ -14403,9 +14403,9 @@
       "license": "ISC"
     },
     "node_modules/simple-icons-font": {
-      "version": "14.14.0",
-      "resolved": "https://registry.npmjs.org/simple-icons-font/-/simple-icons-font-14.14.0.tgz",
-      "integrity": "sha512-w7g2fAylQEXRDdjwemAx9CxQ/1o7KjfaTktvPyDtr6S4UIH0AVgxvYf3jnfKof0n3S2xHAJYby8aOHWB3cpV5A==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/simple-icons-font/-/simple-icons-font-15.0.0.tgz",
+      "integrity": "sha512-y2K6RgE4vGjA0v1nvAtvSwxg0CW4z6NmZ00VTjirvVhMHC60pPKWl9VlYMBaCvTPX032wxIl3eNYO3Zr940FWA==",
       "dev": true,
       "license": "CC0-1.0",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-window": "^1.8.11",
     "sass": "^1.89.0",
     "sass-loader": "^16.0.5",
-    "simple-icons-font": "^14.14.0",
+    "simple-icons-font": "^15.0.0",
     "string-replace-loader": "^3.1.0",
     "style-loader": "^4.0.0",
     "swiper": "^11.2.8",

--- a/src/common/icon-themes/simple-icons-colored-theme.ts
+++ b/src/common/icon-themes/simple-icons-colored-theme.ts
@@ -43,15 +43,8 @@ export class SimpleIconsColoredTheme extends SimpleIconsTheme {
       type: 'list' as const,
       usesTextColor: false,
       listIcons: (searchTerm: string) => {
-        return matchSorter(
-          this.iconNames,
-
-          // Replace special characters in the search term with their replacements.
-          // This is necessary because the icon names from the CSS file are always slugs.
-          searchTerm.replace(
-            this.titleToSlugCharsRegex,
-            (char) => this.titleToSlugReplacements[char]
-          )
+        return matchSorter(this.iconsData, searchTerm, { keys: ['title', 'slug'] }).map(
+          (icon) => icon.slug
         );
       },
     };

--- a/src/common/icon-themes/simple-icons-theme.ts
+++ b/src/common/icon-themes/simple-icons-theme.ts
@@ -9,64 +9,40 @@
 // SPDX-License-Identifier: MIT
 
 import { matchSorter } from 'match-sorter';
+import iconsData from 'simple-icons-font/font/simple-icons.min.json';
 
 import { IIconTheme } from './icon-theme-registry';
 
 /** This class implements an icon theme that uses the Simple Icons font as icons. */
 export class SimpleIconsTheme implements IIconTheme {
-  /** This array contains all available icon names. It is initialized in the constructor. */
-  protected iconNames: Array<string> = [];
+  /**
+   * This array contains all available icon titles and slugs. It is initialized in the
+   * constructor.
+   */
+  protected iconsData: Array<{ title: string; slug: string }> = [];
 
-  /** The replacement map for special characters in the title. */
-  protected titleToSlugReplacements: Record<string, string>;
-
-  /** The regex used to match special characters in the title. */
-  protected titleToSlugCharsRegex: RegExp;
+  /**
+   * This map contains the title of each icon, indexed by its slug. It is initialized in
+   * the constructor.
+   */
+  protected iconTitlesMap: Map<string, string> = new Map();
 
   constructor() {
-    // Load simple-icons.css as text file.
-    const string =
-      require('!!raw-loader!simple-icons-font/font/simple-icons.css').default;
-
-    // Use regex to extract all icon names. In the file above, all the names start with a
-    // '.si-' and end before the next '::before'. We also ensure not to match the variants
-    // with the '--color' suffix.
-    const regex = /\.si-([a-z0-9-_]+(?<!-color))(?=::before)/g;
-    let match;
-
-    while ((match = regex.exec(string)) !== null) {
-      this.iconNames.push(match[1]);
+    // Initialize the iconsData array and the iconTitlesMap with the data from simple-icons.
+    for (const icon of iconsData) {
+      this.iconsData.push({ title: icon.title, slug: icon.slug });
+      this.iconTitlesMap.set(icon.slug, icon.title);
     }
-
-    // The replacement map is copied from the Simple Icons project.
-    // Source: https://github.com/simple-icons/simple-icons/blob/develop/sdk.mjs
-    this.titleToSlugReplacements = {
-      /* eslint-disable @typescript-eslint/naming-convention */
-      '+': 'plus',
-      '.': 'dot',
-      '&': 'and',
-      /* eslint-enable @typescript-eslint/naming-convention */
-      đ: 'd',
-      ħ: 'h',
-      ı: 'i',
-      ĸ: 'k',
-      ŀ: 'l',
-      ł: 'l',
-      ß: 'ss',
-      ŧ: 't',
-      ø: 'o',
-    };
-
-    // Create a regex that matches all characters in the replacement map.
-    this.titleToSlugCharsRegex = new RegExp(
-      `[${Object.keys(this.titleToSlugReplacements).join('')}]`,
-      'g'
-    );
   }
 
   /** Returns a human-readable name of the icon theme. */
   get name() {
     return 'Simple Icons';
+  }
+
+  /** Get the icon title according to the icon slug. */
+  getTitle(slug: string) {
+    return this.iconTitlesMap.get(slug) ?? slug;
   }
 
   /**
@@ -94,15 +70,8 @@ export class SimpleIconsTheme implements IIconTheme {
       type: 'list' as const,
       usesTextColor: true,
       listIcons: (searchTerm: string) => {
-        return matchSorter(
-          this.iconNames,
-
-          // Replace special characters in the search term with their replacements.
-          // This is necessary because the icon names from the CSS file are always slugs.
-          searchTerm.replace(
-            this.titleToSlugCharsRegex,
-            (char) => this.titleToSlugReplacements[char]
-          )
+        return matchSorter(this.iconsData, searchTerm, { keys: ['title', 'slug'] }).map(
+          (icon) => icon.slug
         );
       },
     };

--- a/src/settings-renderer/components/common/GridIconPicker.tsx
+++ b/src/settings-renderer/components/common/GridIconPicker.tsx
@@ -14,6 +14,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeGrid as Grid } from 'react-window';
 
 import { IconThemeRegistry } from '../../../common/icon-themes/icon-theme-registry';
+import { SimpleIconsTheme } from '../../../common/icon-themes/simple-icons-theme';
 import ThemedIcon from './ThemedIcon';
 
 import * as classes from './GridIconPicker.module.scss';
@@ -59,12 +60,14 @@ export default function GridIconPicker(props: IProps) {
   // changes.
   const fetchedIcons = React.useMemo(() => {
     const theme = IconThemeRegistry.getInstance().getTheme(props.theme);
-    return theme.iconPickerInfo.listIcons(props.filterTerm);
+    return { theme, icons: theme.iconPickerInfo.listIcons(props.filterTerm) };
   }, [props.theme, props.filterTerm]);
 
   const columns = 8;
-  const rows = Math.ceil(fetchedIcons.length / columns);
-  const selectedIndex = fetchedIcons.findIndex((icon) => icon === props.selectedIcon);
+  const rows = Math.ceil(fetchedIcons.icons.length / columns);
+  const selectedIndex = fetchedIcons.icons.findIndex(
+    (icon) => icon === props.selectedIcon
+  );
 
   interface ICellProps {
     style: React.CSSProperties;
@@ -75,11 +78,11 @@ export default function GridIconPicker(props: IProps) {
   const cell: React.FC<ICellProps> = ({ style, columnIndex, rowIndex }) => {
     const index = rowIndex * columns + columnIndex;
 
-    if (index >= fetchedIcons.length) {
+    if (index >= fetchedIcons.icons.length) {
       return null;
     }
 
-    const icon = fetchedIcons[index];
+    const icon = fetchedIcons.icons[index];
 
     return (
       <button
@@ -89,7 +92,14 @@ export default function GridIconPicker(props: IProps) {
         })}
         style={style}
         data-tooltip-id="main-tooltip"
-        data-tooltip-content={icon}
+        data-tooltip-content={
+          // If the theme is a SimpleIconsTheme, we can use its getTitle method to
+          // get a more descriptive title for the icon. Otherwise, we just use the
+          // icon name.
+          fetchedIcons.theme instanceof SimpleIconsTheme
+            ? fetchedIcons.theme.getTitle(icon)
+            : icon
+        }
         onClick={() => props.onChange(icon)}
         onDoubleClick={props.onClose}>
         <ThemedIcon name={icon} theme={props.theme} size={'80%'} />


### PR DESCRIPTION
This previous tooltip can only display slugs. ~~I've used a temporary solution to read the icon title from the `simple-icons` package.~~

I've used https://github.com/simple-icons/simple-icons-font/pull/226 (Simple Icons v15), we can read the title from the `simple-icons-font` built-in JSON file instead.

<img width="545" alt="image" src="https://github.com/user-attachments/assets/3561d08d-ef4a-4fe9-9ab5-657663c2fa9f" />
