### PR TITLE
Add support for global-shortcuts portal on Linux

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -31,8 +31,10 @@ import {
   getDefaultGeneralSettings,
   getDefaultMenuSettings,
   IWMInfo,
+  SoundType,
+  ISoundEffect,
 } from '../common';
-import { Settings, DeepReadonly } from './utils/settings';
+import { Settings } from './utils/settings';
 import { Notification } from './utils/notification';
 import { UpdateChecker } from './utils/update-checker';
 import { supportsIsolatedProcesses } from './utils/shell';
@@ -1011,7 +1013,7 @@ export class KandoApp {
         themeVersion: '',
         author: '',
         license: '',
-        sounds: {},
+        sounds: {} as Record<SoundType, ISoundEffect>,
       };
 
       return description;

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -11,7 +11,7 @@
 import i18next from 'i18next';
 import DBus from 'dbus-final';
 
-import { Backend, Shortcut } from '../../../backend';
+import { Backend } from '../../../backend';
 import { IKeySequence } from '../../../../../common';
 import { mapKeys } from '../../../../../common/key-codes';
 
@@ -21,9 +21,9 @@ import { mapKeys } from '../../../../../common/key-codes';
  * extension installed. It would also work on X11, but the generic X11 backend is
  * preferred on X11 as it does not require any extensions.
  */
-export class GnomeBackend implements Backend {
+export class GnomeBackend extends Backend {
   /** This maps GDK shortcut strings to the registered shortcuts. */
-  private callbacks: { [shortcut: string]: () => void } = {};
+  private shortcutMap: { [gdkShortcut: string]: string } = {};
 
   /** This is the DBus interface of the Kando GNOME Shell integration extension. */
   private interface: DBus.ClientInterface;
@@ -60,9 +60,8 @@ export class GnomeBackend implements Backend {
       );
 
       this.interface = obj.getInterface('org.gnome.Shell.Extensions.KandoIntegration');
-
-      this.interface.on('ShortcutPressed', (shortcut: string) => {
-        this.callbacks[shortcut]();
+      this.interface.on('ShortcutPressed', (gdkShortcut: string) => {
+        this.onShortcutPressed(this.shortcutMap[gdkShortcut]);
       });
     } catch (e) {
       throw new Error(
@@ -124,39 +123,44 @@ export class GnomeBackend implements Backend {
   }
 
   /**
-   * This binds a shortcut. The action callback of the shortcut is called when the
-   * shortcut is pressed. On GNOME Wayland, this uses the DBus interface of the Kando
-   * GNOME Shell integration.
+   * On GNOME Wayland, the globalShortcuts module from Electron does not work. Instead, we
+   * use the DBus interface of the Kando GNOME Shell integration extension to bind and
+   * unbind shortcuts.
    *
-   * @param shortcut The shortcut to bind.
-   * @returns A promise which resolves when the shortcut has been bound.
+   * @param shortcuts The shortcuts that should be bound now.
+   * @param previouslyBound The shortcuts that were bound before this call.
+   * @returns A promise which resolves when the shortcuts have been bound.
    */
-  public async bindShortcut(shortcut: Shortcut) {
-    const gdkShortcut = this.toGdkShortcut(shortcut.trigger);
+  protected override async bindShortcutsImpl(
+    shortcuts: string[],
+    previouslyBound: string[]
+  ) {
+    // Use a shortcut if we unbind all shortcuts :)
+    if (shortcuts.length === 0) {
+      await this.interface.UnbindAllShortcuts();
+      return;
+    }
 
-    const success = await this.interface.BindShortcut(gdkShortcut);
+    const shortcutsToUnbind = previouslyBound.filter((s) => !shortcuts.includes(s));
+    const shortcutsToBind = shortcuts.filter((s) => !previouslyBound.includes(s));
 
+    // Unbind the obsolete shortcuts.
+    for (const shortcut of shortcutsToUnbind) {
+      await this.interface.UnbindShortcut(this.toGdkShortcut(shortcut));
+    }
+
+    // Bind the new shortcuts.
+    let success = true;
+    for (const shortcut of shortcutsToBind) {
+      if (!(await this.interface.BindShortcut(this.toGdkShortcut(shortcut)))) {
+        success = false;
+      }
+    }
+
+    // If any of the shortcuts could not be bound, we throw an error.
     if (!success) {
       throw new Error('Invalid shortcut or it is already in use.');
     }
-
-    this.callbacks[gdkShortcut] = shortcut.action;
-  }
-
-  /**
-   * This unbinds a previously bound shortcut.
-   *
-   * @param trigger The trigger of a previously bound.
-   */
-  public async unbindShortcut(trigger: string) {
-    const gdkShortcut = this.toGdkShortcut(trigger);
-    await this.interface.UnbindShortcut(gdkShortcut);
-    delete this.callbacks[gdkShortcut];
-  }
-
-  /** This unbinds all previously bound shortcuts. */
-  public async unbindAllShortcuts() {
-    await this.interface.UnbindAllShortcuts();
   }
 
   /**
@@ -170,6 +174,11 @@ export class GnomeBackend implements Backend {
    * @todo: Add information about the string format of the shortcut.
    */
   private toGdkShortcut(shortcut: string) {
+    const cachedShortcut = this.shortcutMap[shortcut];
+    if (cachedShortcut) {
+      return cachedShortcut;
+    }
+
     if (shortcut.includes('Option')) {
       throw new Error('Shortcuts including Option are not yet supported on GNOME.');
     }
@@ -255,6 +264,8 @@ export class GnomeBackend implements Backend {
       ['numdiv', 'KP_Divide'],
     ]);
 
-    return parts.map((part) => replacements.get(part) || part).join('');
+    const gdkShortcut = parts.map((part) => replacements.get(part) || part).join('');
+    this.shortcutMap[shortcut] = gdkShortcut;
+    return gdkShortcut;
   }
 }

--- a/src/main/backends/linux/portals/desktop-portal.ts
+++ b/src/main/backends/linux/portals/desktop-portal.ts
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import DBus from 'dbus-final';
+import { EventEmitter } from 'events';
 
 /**
  * The type information of DBus.MessageBus does not expose the name of the bus, even if
@@ -20,9 +21,10 @@ interface NamedMessageBus extends DBus.MessageBus {
 
 /**
  * This is the base class for all portals. It provides some common functionality like
- * generating tokens and making requests.
+ * generating tokens and making requests. It extends the EventEmitter class so that
+ * derived classes can emit events.
  */
-export class DesktopPortal {
+export class DesktopPortal extends EventEmitter {
   private bus = DBus.sessionBus() as NamedMessageBus;
 
   /**

--- a/src/main/backends/linux/portals/global-shortcuts.ts
+++ b/src/main/backends/linux/portals/global-shortcuts.ts
@@ -1,0 +1,190 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import DBus from 'dbus-final';
+
+import { DesktopPortal } from './desktop-portal';
+
+/**
+ * The global shortcuts portal is used to bind os-level shortcuts to actions in Kando. We
+ * could use the implementation in Electron / Chromium, but this is a bit limited as of
+ * writing this code. Especially, it is not enabled when running under xwayland and it is
+ * not possible to pass a description for the shortcuts. Hence we opted for our own
+ * implementation.
+ *
+ * The connection to the portal is established lazily, i.e. when the first method is
+ * called. Whenever a new set of shortcuts is requested, a dialog will pop up.
+ *
+ * Whenever one of the bound shortcuts is activated, the 'ShortcutActivated' event is
+ * emitted. The event contains the id of the shortcut which was activated.
+ *
+ * @see https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html
+ */
+export class GlobalShortcuts extends DesktopPortal {
+  /** This is the proxy object for the org.freedesktop.portal.GlobalShortcuts interface. */
+  private interface: DBus.ClientInterface;
+
+  /**
+   * This is the version of the global shortcuts portal. The ConfigureShortcuts method was
+   * not yet available in version 1.
+   */
+  private version = 0;
+
+  /**
+   * This is the token which is used to identify the session. It is generated when the
+   * first method is called.
+   */
+  private session: { token: string; path: string };
+
+  /**
+   * As the connection to the portal is established lazily, we need to make sure that only
+   * one connection is established at a time. This promise is used to achieve this.
+   */
+  private connectPromise: Promise<void>;
+
+  /**
+   * This method tries to connect to the global shortcuts portal. If the connection is
+   * successful, the interface is set and the session is created.
+   *
+   * @returns True if the global shortcuts portal is available, false otherwise.
+   */
+  public async isAvailable() {
+    await this.connect();
+    return !!this.interface;
+  }
+
+  /**
+   * This method returns the version of the global shortcuts portal. The
+   * ConfigureShortcuts method was not yet available in version 1, so you should check the
+   * version before using it.
+   *
+   * @returns The version of the global shortcuts portal. Zero if the portal is not
+   *   available.
+   */
+  public async getVersion(): Promise<number> {
+    await this.connect();
+    return this.version;
+  }
+
+  /**
+   * This method should list all registered shortcuts. On GNOME 48, it does not seem to
+   * work, though.
+   */
+  public async listShortcuts() {
+    await this.connect();
+
+    if (this.interface) {
+      const result = await this.makeRequest((request) => {
+        this.interface.ListShortcuts(this.session.path, {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          handle_token: new DBus.Variant('s', request.token),
+        });
+      });
+
+      if (result.body?.length > 0) {
+        const response = result.body[1];
+        console.log('Shortcuts:', JSON.stringify(response));
+      }
+    }
+  }
+
+  /**
+   * This method binds the given shortcuts to the global shortcuts portal. The shortcuts
+   * are passed as an array of objects, each containing an id and a description. If the
+   * list differs from the currently bound shortcuts, a dialog will pop up asking the user
+   * to confirm the changes.
+   *
+   * @param shortcuts An array of objects, each containing an id and a description.
+   */
+  public async bindShortcuts(shortcuts: { id: string; description: string }[]) {
+    await this.connect();
+
+    if (this.interface) {
+      await this.makeRequest((request) => {
+        this.interface.BindShortcuts(
+          this.session.path,
+          shortcuts.map((shortcut) => [
+            shortcut.id,
+            { description: new DBus.Variant('s', shortcut.description) },
+          ]),
+          '',
+          {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            handle_token: new DBus.Variant('s', request.token),
+          }
+        );
+      });
+    }
+  }
+
+  /**
+   * Connects to the portal if not already connected. It is safe to call this method
+   * multiple times even if the connection is already being established.
+   */
+  private async connect() {
+    if (!this.connectPromise) {
+      this.connectPromise = this.connectImpl();
+    }
+
+    await this.connectPromise;
+  }
+
+  /**
+   * This method establishes the connection to the portal. It is called by connect() and
+   * should not be called directly.
+   */
+  private async connectImpl() {
+    try {
+      await super.init();
+
+      this.interface = this.portals.getInterface(
+        'org.freedesktop.portal.GlobalShortcuts'
+      );
+
+      // Get the version of the global shortcuts portal.
+      const properties = this.portals.getInterface('org.freedesktop.DBus.Properties');
+      const result = await properties.Get(
+        'org.freedesktop.portal.GlobalShortcuts',
+        'version'
+      );
+
+      this.version = result.value;
+      this.session = this.generateToken('session');
+      await this.createSession();
+
+      // Listen for shortcut activation events.
+      this.interface.on('Activated', (handle, id) => {
+        this.emit('ShortcutActivated', id);
+      });
+    } catch (e) {
+      this.interface = undefined;
+      this.session = undefined;
+
+      console.error('Failed to connect to remote desktop portal:', e);
+    }
+  }
+
+  /**
+   * This method creates a new session. It is called by connectImpl() and should not be
+   * called directly.
+   *
+   * @returns A promise which is resolved when the session is created.
+   */
+  private async createSession() {
+    return this.makeRequest((request) => {
+      this.interface.CreateSession({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        handle_token: new DBus.Variant('s', request.token),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        session_handle_token: new DBus.Variant('s', this.session.token),
+      });
+    });
+  }
+}

--- a/src/main/backends/linux/portals/global-shortcuts.ts
+++ b/src/main/backends/linux/portals/global-shortcuts.ts
@@ -73,11 +73,8 @@ export class GlobalShortcuts extends DesktopPortal {
     return this.version;
   }
 
-  /**
-   * This method should list all registered shortcuts. On GNOME 48, it does not seem to
-   * work, though.
-   */
-  public async listShortcuts() {
+  /** This method lists all registered shortcuts. */
+  public async listShortcuts(): Promise<string[]> {
     await this.connect();
 
     if (this.interface) {
@@ -90,9 +87,11 @@ export class GlobalShortcuts extends DesktopPortal {
 
       if (result.body?.length > 0) {
         const response = result.body[1];
-        console.log('Shortcuts:', JSON.stringify(response));
+        return response.shortcuts.value.map((item: [string, unknown]) => item[0]);
       }
     }
+
+    return [];
   }
 
   /**

--- a/src/main/backends/linux/portals/remote-desktop.ts
+++ b/src/main/backends/linux/portals/remote-desktop.ts
@@ -20,7 +20,7 @@ import { DesktopPortal } from './desktop-portal';
  * Kando's backends. The connection to the portal is established lazily, i.e. when the
  * first method is called. This may lead to a dialog asking for permission.
  *
- * @see https://flatpak.github.io/xdg-desktop-portal/docs/#gdbus-org.freedesktop.portal.RemoteDesktop
+ * @see https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html
  */
 export class RemoteDesktop extends DesktopPortal {
   /** This is the proxy object for the org.freedesktop.portal.RemoteDesktop interface. */

--- a/src/main/backends/linux/wlroots/backend.ts
+++ b/src/main/backends/linux/wlroots/backend.ts
@@ -9,8 +9,8 @@
 // SPDX-License-Identifier: MIT
 
 import { native } from './native';
-import { Backend, Shortcut, IWMInfo } from '../../backend';
-import { IBackendInfo, IKeySequence } from '../../../../common';
+import { Backend } from '../../backend';
+import { IKeySequence } from '../../../../common';
 import { mapKeys } from '../../../../common/key-codes';
 
 /**
@@ -21,7 +21,7 @@ import { mapKeys } from '../../../../common/key-codes';
  * - Moving the mouse pointer using the wlr-virtual-pointer-unstable-v1 protocol.
  * - Sending key input using the virtual-keyboard-unstable-v1 protocol.
  */
-export abstract class WLRBackend implements Backend {
+export abstract class WLRBackend extends Backend {
   /**
    * Moves the pointer by the given amount using the native module which uses the
    * wlr-virtual-pointer-unstable-v1 Wayland protocol.
@@ -61,13 +61,4 @@ export abstract class WLRBackend implements Backend {
       native.simulateKey(keyCodes[i], keys[i].down);
     }
   }
-
-  // These methods are abstract and need to be implemented by subclasses. See the docs
-  // of the methods in the Backend interface for more information.
-  abstract init(): Promise<void>;
-  abstract getBackendInfo(): IBackendInfo;
-  abstract getWMInfo(): Promise<IWMInfo>;
-  abstract bindShortcut(shortcut: Shortcut): Promise<void>;
-  abstract unbindShortcut(trigger: string): Promise<void>;
-  abstract unbindAllShortcuts(): Promise<void>;
 }

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -8,9 +8,8 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: MIT
 
-import { globalShortcut } from 'electron';
 import { native } from './native';
-import { Backend, Shortcut } from '../../backend';
+import { Backend } from '../../backend';
 import { IKeySequence } from '../../../../common';
 import { mapKeys } from '../../../../common/key-codes';
 
@@ -22,7 +21,7 @@ import { mapKeys } from '../../../../common/key-codes';
  * environments, but you could also create derived backends for your specific desktop
  * environments if needed.
  */
-export class X11Backend implements Backend {
+export class X11Backend extends Backend {
   /**
    * Override this if another type is more suitable for your desktop environment.
    * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions
@@ -98,32 +97,5 @@ export class X11Backend implements Backend {
 
       native.simulateKey(keyCodes[i], keys[i].down);
     }
-  }
-
-  /**
-   * This binds a shortcut. The action callback of the shortcut is called when the
-   * shortcut is pressed. On X11, this uses Electron's globalShortcut module.
-   *
-   * @param shortcut The shortcut to bind.
-   * @returns A promise which resolves when the shortcut has been bound.
-   */
-  public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
-      throw new Error('Invalid shortcut or it is already in use.');
-    }
-  }
-
-  /**
-   * This unbinds a previously bound shortcut.
-   *
-   * @param trigger The trigger of a previously bound.
-   */
-  public async unbindShortcut(trigger: string) {
-    globalShortcut.unregister(trigger);
-  }
-
-  /** This unbinds all previously bound shortcuts. */
-  public async unbindAllShortcuts() {
-    globalShortcut.unregisterAll();
   }
 }

--- a/src/main/backends/macos/backend.ts
+++ b/src/main/backends/macos/backend.ts
@@ -9,12 +9,12 @@
 // SPDX-License-Identifier: MIT
 
 import { native } from './native';
-import { screen, globalShortcut, app } from 'electron';
-import { Backend, Shortcut } from '../backend';
+import { screen, app } from 'electron';
+import { Backend } from '../backend';
 import { IKeySequence } from '../../../common';
 import { mapKeys } from '../../../common/key-codes';
 
-export class MacosBackend implements Backend {
+export class MacosBackend extends Backend {
   /**
    * On macOS, the window type is set to 'panel'. This makes sure that the window is
    * always on top of other windows and that it is shown on all workspaces.
@@ -89,32 +89,5 @@ export class MacosBackend implements Backend {
 
       native.simulateKey(keyCodes[i], keys[i].down);
     }
-  }
-
-  /**
-   * This binds a shortcut. The action callback of the shortcut is called when the
-   * shortcut is pressed. On macOS, this uses Electron's globalShortcut module.
-   *
-   * @param shortcut The shortcut to bind.
-   * @returns A promise which resolves when the shortcut has been bound.
-   */
-  public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
-      throw new Error('Invalid shortcut or it is already in use.');
-    }
-  }
-
-  /**
-   * This unbinds a previously bound shortcut.
-   *
-   * @param trigger The trigger of a previously bound.
-   */
-  public async unbindShortcut(trigger: string) {
-    globalShortcut.unregister(trigger);
-  }
-
-  /** This unbinds all previously bound shortcuts. */
-  public async unbindAllShortcuts() {
-    globalShortcut.unregisterAll();
   }
 }

--- a/src/main/backends/windows/backend.ts
+++ b/src/main/backends/windows/backend.ts
@@ -9,9 +9,9 @@
 // SPDX-License-Identifier: MIT
 
 import os from 'node:os';
-import { screen, globalShortcut } from 'electron';
+import { screen } from 'electron';
 import { native } from './native';
-import { Backend, Shortcut } from '../backend';
+import { Backend } from '../backend';
 import { IKeySequence } from '../../../common';
 import { mapKeys } from '../../../common/key-codes';
 
@@ -19,7 +19,7 @@ import { mapKeys } from '../../../common/key-codes';
  * This backend is used on Windows. It uses the native Win32 API to simulate key presses
  * and mouse movements. It also uses the Win32 API to get the currently focused window.
  */
-export class WindowsBackend implements Backend {
+export class WindowsBackend extends Backend {
   /**
    * On Windows, the 'toolbar' window type is used. This is actually the only window type
    * supported by Electron on Windows.
@@ -101,33 +101,6 @@ export class WindowsBackend implements Backend {
 
       native.simulateKey(keyCodes[i], keys[i].down);
     }
-  }
-
-  /**
-   * This binds a shortcut. The action callback of the shortcut is called when the
-   * shortcut is pressed. On Windows, this uses Electron's globalShortcut module.
-   *
-   * @param shortcut The shortcut to bind.
-   * @returns A promise which resolves when the shortcut has been bound.
-   */
-  public async bindShortcut(shortcut: Shortcut) {
-    if (!globalShortcut.register(shortcut.trigger, shortcut.action)) {
-      throw new Error('Invalid shortcut or it is already in use.');
-    }
-  }
-
-  /**
-   * This unbinds a previously bound shortcut.
-   *
-   * @param trigger The trigger of a previously bound.
-   */
-  public async unbindShortcut(trigger: string) {
-    globalShortcut.unregister(trigger);
-  }
-
-  /** This unbinds all previously bound shortcuts. */
-  public async unbindAllShortcuts() {
-    globalShortcut.unregisterAll();
   }
 
   /**


### PR DESCRIPTION
With this PR, Kando tries to use the global shortcuts portal on KDE Wayland if it is available. This can potentially fix #855.