### PR TITLE
Fix reloading sound themes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -80,6 +80,7 @@ They are marked with a **:collision:** emoji below.
 - Gamepad input on Linux when using [input-gamepad](https://github.com/sezanzeb/input-remapper).
 - A bug which made it possible to sometimes open the settings dialog by pressing <kbd>Space</kbd> while the menu was open.
 - A crash if no focused window existed when opening a menu on qTile.
+- Reloading sound theme files which were changed on disk. Before, only changes to the `theme.json` file were reloaded when the sound theme was reloaded. Now, all sound files are reloaded as well.
 
 ## [Kando 1.8.0](https://github.com/kando-menu/kando/releases/tag/v1.8.0)
 

--- a/src/menu-renderer/sound-theme.ts
+++ b/src/menu-renderer/sound-theme.ts
@@ -27,12 +27,19 @@ export class SoundTheme {
   private volume: number = 0.5;
 
   /**
+   * This is increased each time the sound theme is reloaded. It is used to ensure that
+   * the sound files are reloaded from disk instead of being cached by the browser.
+   */
+  private reloadCounter: number = 0;
+
+  /**
    * Loads the given theme description.
    *
    * @param description The description of the sound theme to load.
    */
   public loadDescription(description: ISoundThemeDescription) {
     this.description = description;
+    this.reloadCounter++;
   }
 
   /**
@@ -59,7 +66,10 @@ export class SoundTheme {
         '/' +
         this.description.id +
         '/' +
-        sound.file;
+        sound.file +
+        '?v=' +
+        this.reloadCounter; // Append reload counter to force reloading the sound file.
+
       const minRate = sound.minPitch || 1;
       const maxRate = sound.maxPitch || 1;
       const rate = Math.random() * (maxRate - minRate) + minRate;


### PR DESCRIPTION
Before, only changes to the `theme.json` file were reloaded when the sound theme was reloaded. Now, all sound files are reloaded as well.