### PR TITLE
System icons

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - **Visualization of the selection wedges!** Menu themes can now draw the circle segments belonging to the menu items as well as separator lines between them. The Neon Lights theme and the Default theme have been updated to use this feature.
 - **Circle wrapping for the center text!** The center text is now wrapped in a circle instead of a rectangle. This makes it look better and allows longer texts to be displayed without clipping.
 - **Automatic font-size reduction for the center text!** If the center text is too long to fit into the circle, it will now be automatically reduced in size so it fits.
+- **A System-Icons Theme for Linux!** This allows you to use the system icons of your desktop environment as icons for menu items. This is still somewhat experimental, but it should work on most desktop environments. Feel free to test it and report any issues you encounter!
 
 ### :wrench: Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "react-transition-group": "^4.4.5",
         "react-virtualized-auto-sizer": "^1.0.25",
         "react-window": "^1.8.11",
+        "read-ini-file": "^4.0.0",
         "sass": "^1.89.2",
         "sass-loader": "^16.0.5",
         "simple-icons-font": "^15.7.0",
@@ -13268,6 +13269,40 @@
       },
       "bin": {
         "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/read-ini-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-ini-file/-/read-ini-file-4.0.0.tgz",
+      "integrity": "sha512-zz4qv/sKETv7nAkATqSJ9YMbKD8NXRPuA8d17VdYCuNYrVstB1S6UAMU6aytf5vRa9MESbZN7jLZdcmrOxz4gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^3.0.1",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/read-ini-file/node_modules/ini": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/read-ini-file/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.25",
     "react-window": "^1.8.11",
+    "read-ini-file": "^4.0.0",
     "sass": "^1.89.2",
     "sass-loader": "^16.0.5",
     "simple-icons-font": "^15.7.0",

--- a/src/common/common-window-api.ts
+++ b/src/common/common-window-api.ts
@@ -104,7 +104,7 @@ export const COMMON_WINDOW_API = {
     },
   },
 
-  /** This will return a IIconThemesInfo describing all available icon themes. */
+  /** This will return a IIconThemesInfo describing all available user icon themes. */
   getIconThemes: (): Promise<IIconThemesInfo> => {
     return ipcRenderer.invoke('common.get-icon-themes');
   },
@@ -146,6 +146,11 @@ export const COMMON_WINDOW_API = {
   /** This will return the descriptions of the currently used sound theme. */
   getSoundTheme: (): Promise<ISoundThemeDescription> => {
     return ipcRenderer.invoke('common.get-sound-theme');
+  },
+
+  /** This lists all currently available system icons. */
+  getSystemIcons: (): Promise<Array<string>> => {
+    return ipcRenderer.invoke('common.get-system-icons');
   },
 };
 

--- a/src/common/icon-themes/fallback-theme.ts
+++ b/src/common/icon-themes/fallback-theme.ts
@@ -25,7 +25,8 @@ export class FallbackTheme implements IIconTheme {
    *
    * @returns A div element that contains the icon.
    */
-  createIcon() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  createIcon(name: string) {
     const containerDiv = document.createElement('div');
     containerDiv.classList.add('icon-container');
 

--- a/src/common/icon-themes/icon-theme-registry.ts
+++ b/src/common/icon-themes/icon-theme-registry.ts
@@ -99,10 +99,7 @@ export class IconThemeRegistry {
     this.iconThemes.set('base64', new Base64Theme());
 
     // Add the system icon theme if available.
-    const systemIcons = await window.commonAPI.getSystemIcons();
-    if (systemIcons.length > 0) {
-      this.iconThemes.set('system', new SystemTheme(systemIcons));
-    }
+    await this.reloadSystemIcons();
 
     // Add an icon theme for all icon themes in the user's icon theme directory.
     const info = await window.commonAPI.getIconThemes();
@@ -150,7 +147,14 @@ export class IconThemeRegistry {
    * @returns A div element that contains the icon.
    */
   public createIcon(theme: string, icon: string): HTMLElement {
-    return this.getTheme(theme).createIcon(icon);
+    const div = this.getTheme(theme).createIcon(icon);
+
+    if (!div) {
+      console.warn(`Icon "${icon}" not found in theme "${theme}". Using fallback.`);
+      return this.fallbackTheme.createIcon('');
+    }
+
+    return div;
   }
 
   /**
@@ -161,5 +165,18 @@ export class IconThemeRegistry {
    */
   public getIconPickerInfo(theme: string) {
     return this.getTheme(theme).iconPickerInfo;
+  }
+
+  /**
+   * Reloads the system icons. This is used to update the system icon theme if it has
+   * changed.
+   */
+  public async reloadSystemIcons() {
+    const systemIcons = await window.commonAPI.getSystemIcons();
+    if (systemIcons.length > 0) {
+      this.iconThemes.set('system', new SystemTheme(systemIcons));
+    } else {
+      this.iconThemes.delete('system');
+    }
   }
 }

--- a/src/common/icon-themes/icon-theme-registry.ts
+++ b/src/common/icon-themes/icon-theme-registry.ts
@@ -18,6 +18,7 @@ import { EmojiTheme } from './emoji-theme';
 import { FileIconTheme } from './file-icon-theme';
 import { FallbackTheme } from './fallback-theme';
 import { Base64Theme } from './base64-theme';
+import { SystemTheme } from './system-theme';
 
 /**
  * This interface describes an icon theme. An icon theme is a collection of icons that can
@@ -96,6 +97,12 @@ export class IconThemeRegistry {
     this.iconThemes.set('material-symbols-rounded', new MaterialSymbolsTheme());
     this.iconThemes.set('emoji', new EmojiTheme());
     this.iconThemes.set('base64', new Base64Theme());
+
+    // Add the system icon theme if available.
+    const systemIcons = await window.commonAPI.getSystemIcons();
+    if (systemIcons.length > 0) {
+      this.iconThemes.set('system', new SystemTheme(systemIcons));
+    }
 
     // Add an icon theme for all icon themes in the user's icon theme directory.
     const info = await window.commonAPI.getIconThemes();

--- a/src/common/icon-themes/system-theme.ts
+++ b/src/common/icon-themes/system-theme.ts
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/menu/kando           //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { matchSorter } from 'match-sorter';
+
+import { IIconTheme } from './icon-theme-registry';
+
+/**
+ * On some systems, the operating system provides a set of icons that can be used in
+ * applications. For instance, on Linux, the Freedesktop Icon Theme Specification defines
+ * a set of icons that can be used by applications.
+ */
+export class SystemTheme implements IIconTheme {
+  /** A list of all available icon names. */
+  private icons: Array<string> = [];
+
+  /** A map of icon names to the file paths of the icons. */
+  private iconPaths: Record<string, string> = {};
+
+  /** A human-readable name of the icon theme. */
+  get name() {
+    return 'System Icons';
+  }
+
+  /**
+   * Creates a new SystemTheme.
+   *
+   * @param paths The absolute file paths to the icons.
+   */
+  constructor(paths: string[]) {
+    paths.forEach((path) => {
+      const url = new URL(`file://${path}`);
+      let name = url.pathname.split('/').pop() || ''; // Extract the file name.
+      name = name.replace(/\.[^/.]+$/, ''); // Remove the extension.
+      this.icons.push(name);
+      this.iconPaths[name] = path;
+    });
+  }
+
+  /** Creates a div element that contains the icon with the given name. */
+  createIcon(icon: string) {
+    const iconPath = this.iconPaths[icon];
+    if (!iconPath) {
+      return null;
+    }
+
+    const containerDiv = document.createElement('div');
+    containerDiv.classList.add('icon-container');
+
+    const iconDiv = document.createElement('img');
+    iconDiv.src = `file://${iconPath}`;
+    iconDiv.draggable = false;
+
+    containerDiv.appendChild(iconDiv);
+
+    return containerDiv;
+  }
+
+  /** Returns information about the icon picker for this icon theme. */
+  get iconPickerInfo() {
+    return {
+      type: 'list' as const,
+      usesTextColor: false,
+      listIcons: (searchTerm: string) => matchSorter(this.icons, searchTerm),
+    };
+  }
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -460,6 +460,12 @@ export interface IShowMenuOptions {
    * be selected by only hovering over them.
    */
   hoverMode: boolean;
+
+  /**
+   * If this is set, the system-icon theme has changed since the last time the menu was
+   * opened. This is used to determine if the menu needs to be reloaded.
+   */
+  systemIconsChanged: boolean;
 }
 
 /** The user can create menu collections to group menus according to their tags. */

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -722,6 +722,11 @@ export class KandoApp {
     ipcMain.handle('common.get-sound-theme', async () => {
       return this.loadSoundThemeDescription(this.generalSettings.get('soundTheme'));
     });
+
+    // Allow the renderer to retrieve all system icons.
+    ipcMain.handle('common.get-system-icons', async () => {
+      return this.backend.getSystemIcons();
+    });
   }
 
   /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -362,7 +362,10 @@ export class KandoApp {
       await this.menuWindow.load();
     }
 
-    const wmInfo = await this.backend.getWMInfo();
+    const [wmInfo, systemIconsChanged] = await Promise.all([
+      this.backend.getWMInfo(),
+      this.backend.systemIconsChanged(),
+    ]);
 
     // If a menu is already shown, we do not need the window information from the backend
     // as now Kando will be in focus. We use the old information instead.
@@ -374,7 +377,7 @@ export class KandoApp {
     this.lastWMInfo = wmInfo;
 
     try {
-      this.menuWindow.showMenu(request, this.lastWMInfo);
+      this.menuWindow.showMenu(request, this.lastWMInfo, systemIconsChanged);
     } catch (error) {
       Notification.showError('Failed to show menu', error.message || error);
     }

--- a/src/main/backends/backend.ts
+++ b/src/main/backends/backend.ts
@@ -82,6 +82,21 @@ export abstract class Backend extends EventEmitter {
   }
 
   /**
+   * Each backend can provide a way to detect changes to the system icons. This method
+   * should return true if the system icon theme has changed since the last call to
+   * getSystemIcons().
+   *
+   * @returns A promise which resolves to true if the system icon theme has changed since
+   *   the last call to getSystemIcons(), or false if it has not changed or if this is not
+   *   implemented by the backend.
+   */
+  public async systemIconsChanged(): Promise<boolean> {
+    // This method is not implemented by the base class, but can be implemented by
+    // derived backends if they support detecting changes to system icons.
+    return false;
+  }
+
+  /**
    * Each backend must provide a way to move the pointer.
    *
    * @param dx The amount of horizontal movement.

--- a/src/main/backends/backend.ts
+++ b/src/main/backends/backend.ts
@@ -68,6 +68,20 @@ export abstract class Backend extends EventEmitter {
   public abstract getWMInfo(): Promise<IWMInfo>;
 
   /**
+   * Each backend can provide a way to list available system icons. The method should
+   * return an array of absolute file paths to the icons. This is used to create the
+   * system icon theme.
+   *
+   * @returns A promise which resolves to an array of absolute file paths to the system
+   *   icons. If system icons are not available, it should resolve to an empty array.
+   */
+  public async getSystemIcons(): Promise<Array<string>> {
+    // This method is not implemented by the base class, but can be implemented by
+    // derived backends if they support listing system icons.
+    return [];
+  }
+
+  /**
    * Each backend must provide a way to move the pointer.
    *
    * @param dx The amount of horizontal movement.

--- a/src/main/backends/linux/backend.ts
+++ b/src/main/backends/linux/backend.ts
@@ -87,9 +87,10 @@ export abstract class LinuxBackend extends Backend {
     const endTime = performance.now();
     const timeTaken = endTime - startTime;
 
-    console.log(
-      `Found ${icons.length} ${this.currentTheme} icons in ${timeTaken.toFixed(2)}ms.`
+    console.debug(
+      `Found ${icons.length} ${this.currentTheme} icons in ${timeTaken.toFixed(0)} ms.`
     );
+
     return icons;
   }
 

--- a/src/main/backends/linux/backend.ts
+++ b/src/main/backends/linux/backend.ts
@@ -1,0 +1,331 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { readIniFile } from 'read-ini-file';
+import { execSync } from 'child_process';
+
+import { Backend } from '../backend';
+
+/**
+ * This generic Linux backend class provides the basic functionality for all Linux
+ * backends. For now, this is just getting the system icons according to the Freedesktop
+ * Icon Theme Specification.
+ */
+export abstract class LinuxBackend extends Backend {
+  private iconSearchPaths: string[] = [];
+
+  constructor() {
+    super();
+
+    // List of paths to search for icons. The order is important, if a theme is found in
+    // multiple locations, the first one has priority.
+    const home = os.homedir();
+    this.iconSearchPaths = [
+      path.join(home, '.icons/'),
+      path.join(home, '.local/share/icons/'),
+      path.join(home, '.local/share/pixmaps/'),
+      path.join(home, '.pixmaps/'),
+    ];
+    process.env.XDG_DATA_DIRS?.split(':').forEach((dir) => {
+      this.iconSearchPaths.push(path.join(dir, 'icons/'));
+    });
+    this.iconSearchPaths.push('/usr/share/icons/');
+    this.iconSearchPaths.push('/usr/local/share/icons/');
+    this.iconSearchPaths.push('/usr/share/pixmaps/');
+    this.iconSearchPaths.push('/usr/local/share/pixmaps/');
+
+    // Make search paths unique.
+    this.iconSearchPaths = this.iconSearchPaths.filter(
+      (item, index) => this.iconSearchPaths.indexOf(item) === index
+    );
+  }
+
+  /**
+   * This returns the icons that are available in the current icon theme according to the
+   * Freedesktop Icon Theme Specification. More information can be found here:
+   * https://specifications.freedesktop.org/icon-theme-spec/latest/).
+   *
+   * It excludes some categories like "animations", or "emblems" that are usually not so
+   * useful in a pie menu. Also, if some icons are only available below 48px size, they
+   * are excluded as well. Only icons in SVG or PNG format are returned. If an icon is
+   * available in both formats, the SVG version is preferred.
+   *
+   * @returns A list absolute file paths to the icons.
+   */
+  public override async getSystemIcons(): Promise<Array<string>> {
+    const startTime = performance.now();
+
+    const currentTheme = await this.getCurrentIconTheme();
+    const allThemeDirectories = await this.getThemeDirectoriesRecursively(currentTheme);
+    const icons = await this.getIcons(
+      allThemeDirectories,
+      ['apps', 'actions', 'devices', 'mimetypes'],
+      ['scalable', '48x48', '48'],
+      ['.svg', '.png']
+    );
+
+    const endTime = performance.now();
+    const timeTaken = endTime - startTime;
+
+    console.log(
+      `Found ${icons.length} ${currentTheme} icons in ${timeTaken.toFixed(2)}ms.`
+    );
+    return icons;
+  }
+
+  /**
+   * This method retrieves the current icon theme from the system. It checks various
+   * desktop environments (GNOME, KDE, XFCE) and their respective configuration files to
+   * find the currently set icon theme. If no specific theme is found, it defaults to
+   * 'hicolor', which is a standard fallback theme according to the Freedesktop Icon Theme
+   * Specification.
+   *
+   * @returns A promise that resolves to the name of the current icon theme as a string.
+   */
+  private async getCurrentIconTheme(): Promise<string> {
+    // Check the environment variable first.
+    if (process.env.ICON_THEME) {
+      return process.env.ICON_THEME;
+    }
+
+    const home = os.homedir();
+
+    const tryGNOME = () => {
+      try {
+        const output = execSync('gsettings get org.gnome.desktop.interface icon-theme', {
+          encoding: 'utf8',
+        }).trim();
+        return output.replace(/^'|'$/g, ''); // remove surrounding quotes
+      } catch {
+        return null;
+      }
+    };
+
+    const tryKDE = async () => {
+      const kdeFile = path.join(home, '.config', 'kdeglobals');
+      if (!fs.existsSync(kdeFile)) {
+        return null;
+      }
+      try {
+        const data = (await readIniFile(kdeFile)) as {
+          ['Icons']?: { ['Theme']?: string };
+        };
+        return data?.Icons?.Theme || null;
+      } catch {
+        return null;
+      }
+    };
+
+    const tryXFCE = () => {
+      try {
+        const output = execSync('xfconf-query -c xsettings -p /Net/IconThemeName', {
+          encoding: 'utf8',
+        }).trim();
+        return output || null;
+      } catch {
+        return null;
+      }
+    };
+
+    const tryGTKSettings = async () => {
+      const gtkFile = path.join(home, '.config', 'gtk-3.0', 'settings.ini');
+      if (!fs.existsSync(gtkFile)) {
+        return null;
+      }
+      try {
+        const data = (await readIniFile(gtkFile)) as {
+          ['Settings']?: { ['gtk-icon-theme-name']?: string };
+        };
+        return data?.Settings?.['gtk-icon-theme-name'] || null;
+      } catch {
+        return null;
+      }
+    };
+
+    const desktop = process.env.XDG_CURRENT_DESKTOP || '';
+
+    switch (desktop.toLowerCase()) {
+      case 'gnome':
+        return tryGNOME() || (await tryGTKSettings()) || 'hicolor';
+      case 'kde':
+        return (await tryKDE()) || (await tryGTKSettings()) || 'hicolor';
+      case 'xfce':
+        return tryXFCE() || (await tryGTKSettings()) || 'hicolor';
+    }
+
+    return (
+      tryGNOME() || (await tryKDE()) || tryXFCE() || (await tryGTKSettings()) || 'hicolor'
+    );
+  }
+
+  /**
+   * This method finds the directories of a given icon theme by searching common locations
+   * where icon themes are stored on Linux systems. It returns an array of paths where the
+   * icons for the specified theme are located. According to the Freedesktop Icon Theme
+   * Specification, an icon theme can be spread across multiple directories.
+   *
+   * @param themeName The name of the icon theme to search for.
+   * @returns A promise that resolves to an array of paths where the icon theme is
+   *   located.
+   */
+  private async getThemeDirectories(themeName: string): Promise<string[]> {
+    const paths: string[] = [];
+
+    // Check each path for the theme directory.
+    for (const basePath of this.iconSearchPaths) {
+      const themePath = path.join(basePath, themeName, 'index.theme');
+      try {
+        // Check if the file exists.
+        await fs.promises.access(themePath);
+        paths.push(path.dirname(themePath));
+      } catch {
+        continue;
+      }
+    }
+
+    return paths;
+  }
+
+  /**
+   * This method retrieves the list of icon themes that the given theme inherits from. It
+   * reads the `index.theme` files of the theme and returns the names of the inherited
+   * themes.
+   *
+   * @param themeName The name of the icon theme to check for inherited themes.
+   * @returns A promise that resolves to an array of names of inherited themes.
+   */
+  private async getInheritedThemes(themeName: string): Promise<string[]> {
+    const themeDirectories = await this.getThemeDirectories(themeName);
+    if (themeDirectories.length === 0) {
+      return [];
+    }
+
+    const inheritedThemes: string[] = [];
+    for (const themeDirectory of themeDirectories) {
+      try {
+        const data = (await readIniFile(path.join(themeDirectory, 'index.theme'))) as {
+          ['Icon Theme']?: { ['Inherits']?: string };
+        };
+        let inherits =
+          data['Icon Theme']?.['Inherits']?.split(',').map((name) => name.trim()) || [];
+        inherits = inherits.filter((name) => inheritedThemes.indexOf(name) === -1);
+        inheritedThemes.push(...inherits);
+      } catch {
+        // If the index.theme file cannot be read, we simply ignore this directory.
+        continue;
+      }
+    }
+
+    if (inheritedThemes.length === 0) {
+      return ['hicolor'];
+    }
+
+    return inheritedThemes;
+  }
+
+  /**
+   * This method retrieves all inherited themes for a given theme name, including
+   * recursively inherited themes. The result is an array of theme names, with the
+   * original theme name as the first element and all inherited themes following it.
+   *
+   * @param themeName The name of the icon theme to check for inherited themes.
+   * @returns A promise that resolves to an array of names of all inherited themes,
+   *   including the given theme name as the first element.
+   */
+  private async getInheritedThemesRecursively(themeName: string): Promise<string[]> {
+    const themes = [themeName];
+    let inheritedThemes = await this.getInheritedThemes(themeName);
+    while (inheritedThemes.length > 0) {
+      const newThemes = inheritedThemes.filter((theme) => !themes.includes(theme));
+      themes.push(...newThemes);
+      inheritedThemes = (
+        await Promise.all(newThemes.map((theme) => this.getInheritedThemes(theme)))
+      ).flat();
+    }
+    return themes;
+  }
+
+  /**
+   * This method returns all directories where the icons of the current icon theme are
+   * located, including directories of inherited themes.
+   *
+   * @param themeName The name of the icon theme to check for directories.
+   * @returns A promise that resolves to an array of paths where the icons of the theme
+   *   are located.
+   */
+  private async getThemeDirectoriesRecursively(themeName: string): Promise<string[]> {
+    const themes = await this.getInheritedThemesRecursively(themeName);
+    const directories: string[] = [];
+    for (const theme of themes) {
+      const themeDirectories = await this.getThemeDirectories(theme);
+      directories.push(...themeDirectories);
+    }
+    return directories;
+  }
+
+  /**
+   * This method retrieves the icons from the specified base paths, contexts, sizes, and
+   * file types. It will look into all base paths. Icons found in the first base path will
+   * be preferred over icons found in later base paths. The same applies to the sizes: if
+   * an icon is available in multiple sizes, the first one found will be used. Only icons
+   * that match the specified contexts and file types will be returned.
+   *
+   * @param basePaths The base paths to search for icons.
+   * @param contexts The contexts in which the icons are used (e.g., 'apps', 'actions').
+   * @param sizes The sizes of the icons to retrieve (e.g., 'scalable', '48x48').
+   * @param fileTypes The file types of the icons to retrieve (e.g., '.svg', '.png').
+   * @returns A promise that resolves to an array of absolute file paths to the icons that
+   *   match the specified criteria.
+   */
+  private async getIcons(
+    basePaths: string[],
+    contexts: string[],
+    sizes: string[],
+    fileTypes: string[]
+  ): Promise<string[]> {
+    // Maps icon names to their absolute file paths.
+    const icons = new Map<string, string>();
+
+    // Iterate over all base paths backwards to ensure that icons from the first path
+    // overwrite icons from later paths.
+    for (const basePath of basePaths.reverse()) {
+      for (const size of sizes.reverse()) {
+        for (const context of contexts) {
+          // Some themes sort first by size, some by context.
+          const directories = [
+            path.join(basePath, context, size),
+            path.join(basePath, size, context),
+          ];
+
+          // Check each directory for icons.
+          for (const dir of directories) {
+            if (!fs.existsSync(dir)) {
+              continue; // Skip if the directory does not exist.
+            }
+            const files = await fs.promises.readdir(dir);
+            for (const file of files) {
+              const ext = path.extname(file).toLowerCase();
+              if (fileTypes.includes(ext)) {
+                const iconName = path.basename(file, ext);
+                icons.set(iconName, path.join(dir, file));
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Convert the map to an array of absolute file paths.
+    return Array.from(icons.values());
+  }
+}

--- a/src/main/backends/linux/gnome/wayland/backend.ts
+++ b/src/main/backends/linux/gnome/wayland/backend.ts
@@ -11,7 +11,7 @@
 import i18next from 'i18next';
 import DBus from 'dbus-final';
 
-import { Backend } from '../../../backend';
+import { LinuxBackend } from '../../backend';
 import { IKeySequence } from '../../../../../common';
 import { mapKeys } from '../../../../../common/key-codes';
 import { screen } from 'electron';
@@ -22,7 +22,7 @@ import { screen } from 'electron';
  * extension installed. It would also work on X11, but the generic X11 backend is
  * preferred on X11 as it does not require any extensions.
  */
-export class GnomeBackend extends Backend {
+export class GnomeBackend extends LinuxBackend {
   /**
    * This maps GDK shortcut strings to the registered shortcuts. This is required because
    * we want to emit the 'shortcutPressed' event with the original shortcut string, but

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -14,7 +14,7 @@ import fs from 'fs';
 import DBus from 'dbus-final';
 import { exec } from 'child_process';
 
-import { Backend } from '../../../backend';
+import { LinuxBackend } from '../../backend';
 import { RemoteDesktop } from '../../portals/remote-desktop';
 import { GlobalShortcuts } from '../../portals/global-shortcuts';
 import { IKeySequence, IWMInfo } from '../../../../../common';
@@ -33,7 +33,7 @@ import { screen } from 'electron';
  * request for a corresponding desktop portal:
  * https://github.com/flatpak/xdg-desktop-portal/issues/304
  */
-export class KDEWaylandBackend extends Backend {
+export class KDEWaylandBackend extends LinuxBackend {
   /** Here we store the current KWin version as [major, minor, patch]. */
   private kwinVersion: number[];
 

--- a/src/main/backends/linux/wlroots/backend.ts
+++ b/src/main/backends/linux/wlroots/backend.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import { native } from './native';
-import { Backend } from '../../backend';
+import { LinuxBackend } from '../backend';
 import { IKeySequence } from '../../../../common';
 import { mapKeys } from '../../../../common/key-codes';
 
@@ -21,7 +21,7 @@ import { mapKeys } from '../../../../common/key-codes';
  * - Moving the mouse pointer using the wlr-virtual-pointer-unstable-v1 protocol.
  * - Sending key input using the virtual-keyboard-unstable-v1 protocol.
  */
-export abstract class WLRBackend extends Backend {
+export abstract class WLRBackend extends LinuxBackend {
   /**
    * Moves the pointer by the given amount using the native module which uses the
    * wlr-virtual-pointer-unstable-v1 Wayland protocol.

--- a/src/main/backends/linux/x11/backend.ts
+++ b/src/main/backends/linux/x11/backend.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 
 import { native } from './native';
-import { Backend } from '../../backend';
+import { LinuxBackend } from '../backend';
 import { IKeySequence } from '../../../../common';
 import { mapKeys } from '../../../../common/key-codes';
 import { screen } from 'electron';
@@ -22,7 +22,7 @@ import { screen } from 'electron';
  * environments, but you could also create derived backends for your specific desktop
  * environments if needed.
  */
-export class X11Backend extends Backend {
+export class X11Backend extends LinuxBackend {
   /**
    * Override this if another type is more suitable for your desktop environment.
    * https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions

--- a/src/main/menu-window.ts
+++ b/src/main/menu-window.ts
@@ -125,8 +125,14 @@ export class MenuWindow extends BrowserWindow {
    *
    * @param request Required information to select correct menu.
    * @param info Information about current desktop environment.
+   * @param systemIconsChanged True if the system icon theme has changed since the last
+   *   time the menu was shown.
    */
-  public showMenu(request: Partial<IShowMenuRequest>, info: IWMInfo) {
+  public showMenu(
+    request: Partial<IShowMenuRequest>,
+    info: IWMInfo,
+    systemIconsChanged: boolean
+  ) {
     const sameShortcutBehavior = this.kando
       .getGeneralSettings()
       .get('sameShortcutBehavior');
@@ -246,6 +252,7 @@ export class MenuWindow extends BrowserWindow {
         centeredMode: this.lastMenu.centered,
         anchoredMode: this.lastMenu.anchored,
         hoverMode: this.lastMenu.hoverMode,
+        systemIconsChanged,
       },
       {
         appName: info.appName,

--- a/src/menu-renderer/index.ts
+++ b/src/menu-renderer/index.ts
@@ -107,7 +107,10 @@ Promise.all([
   );
 
   // Show the menu when the main process requests it.
-  window.menuAPI.onShowMenu((root, menuOptions) => {
+  window.menuAPI.onShowMenu(async (root, menuOptions) => {
+    if (menuOptions.systemIconsChanged) {
+      await IconThemeRegistry.getInstance().reloadSystemIcons();
+    }
     menu.show(root, menuOptions);
     settingsButton.show();
   });


### PR DESCRIPTION
This PR allows you to use your Linux system icons as icons for menu items. This is still somewhat experimental, but it should work on most desktop environments. Feel free to test it and report any issues you encounter!