### PR TITLE
Fix issue #1065

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 ### :bug: Fixed
 
 - Rendering of SVG icons which contain CSS styles. If multiple SVG icons with the same CSS classes were used in the same menu, the styles clashed resulting in wrong colors.
+- A bug which prevented the settings to be shown when a second instance of Kando was started on macOS.
 
 ## [Kando 2.0.0](https://github.com/kando-menu/kando/releases/tag/v2.0.0)
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -213,6 +213,12 @@ app
       handleArguments(options, argv[argv.length - 1], true);
     });
 
+    // This is called when the app is activated, for example when the user clicks on the
+    // app in the launchpad of macOS. We show the settings.
+    app.on('activate', () => {
+      kando.showSettings();
+    });
+
     // Handle the case when the app is opened via a deep link. This is only called on
     // macOS, on Windows and Linux deep links are handled by the second-instance event.
     app.on('open-url', (e, url) => {


### PR DESCRIPTION
This should make the app show the settings when a second instance of the app is started on macOS.