### PR TITLE
:bug: Fix incorrect `lastStickPosition` usage

### DIFF
--- a/src/menu-renderer/input-methods/gamepad.ts
+++ b/src/menu-renderer/input-methods/gamepad.ts
@@ -163,7 +163,11 @@ export class Gamepad extends EventEmitter {
    */
   private onButtonChange(gamepadIndex: number, buttonIndex: number) {
     const pressed = this.gamepadStates[gamepadIndex].buttons[buttonIndex].pressed;
-    this.emit(pressed ? 'buttondown' : 'buttonup', buttonIndex, this.lastStickPosition);
+    this.emit(
+      pressed ? 'buttondown' : 'buttonup',
+      buttonIndex,
+      this.gamepadStates[gamepadIndex].lastStickPosition
+    );
   }
 
   /**


### PR DESCRIPTION
It looks like the code reads the `lastStickPosition` from the wrong place.

<img width="2494" height="502" alt="CleanShot 2025-08-23 at 18 09 25@2x" src="https://github.com/user-attachments/assets/4df9f613-d5cc-4368-b23d-3b634aaa8f7f" />

Please correct me if I'm wrong.