### PR TITLE
:wrench: Fix types for `menuSettings.set()`

### DIFF
--- a/src/common/common-window-api.ts
+++ b/src/common/common-window-api.ts
@@ -83,7 +83,7 @@ export const COMMON_WINDOW_API = {
     get: function (): Promise<MenuSettings> {
       return ipcRenderer.invoke('common.menu-settings-get');
     },
-    set: function (data: MenuSettings): void {
+    set: function (data: Partial<MenuSettings>): void {
       ipcRenderer.send('common.menu-settings-set', data);
     },
     onChange: function (


### PR DESCRIPTION
The type error is from the `common-windows-api.ts`. We should use `Partial<T>` for its incoming type.

<img width="964" height="262" alt="CleanShot 2025-08-23 at 18 17 11@2x" src="https://github.com/user-attachments/assets/eb73be9f-d0ae-4fc4-87cb-21887d4fe20e" />
