### PR TITLE
Fix key-up item selections even if turbo mode is disabled

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 - Custom fonts in the settings dialog and in the menu. If you used a custom font in your system, this was not respected everywhere in Kando. Now, all widgets should use your custom font. Some menu themes may override this, but the default themes should all use the system font.
 - An issue which caused menu items in the menu editor to be selected when the user clicked somewhere and then dragged the mouse over the item.  Thanks to [@Maksym](https://github.com/AluctuatioAetern) for this contribution!
 - A bug which made it possible to change the path of an open-file item manually.
+- A bug which made it possible to select items with key-up events even if turbo-mode was disabled.
 
 ## [Kando 2.0.0](https://github.com/kando-menu/kando/releases/tag/v2.0.0)
 

--- a/src/menu-renderer/input-methods/pointer-input.ts
+++ b/src/menu-renderer/input-methods/pointer-input.ts
@@ -288,6 +288,11 @@ export class PointerInput extends InputMethod {
    * @param event The keyboard event.
    */
   public onKeyUpEvent(event: KeyboardEvent) {
+    // Key-up events only matter if turbo mode is enabled.
+    if (!this.enableTurboMode) {
+      return;
+    }
+
     // On some (all?) Linux environments, event.metaKey is not false even if the key has
     // been released with this event. Therefore, we explicitly check if the key was
     // released: https://github.com/kando-menu/kando/issues/788


### PR DESCRIPTION
This fixes #1128.