### PR TITLE
🐛 Add 0.5s timeout to WLRoots backend for mouse position fetching

### DIFF
--- a/src/main/backends/linux/wlroots/backend.ts
+++ b/src/main/backends/linux/wlroots/backend.ts
@@ -73,6 +73,10 @@ export abstract class WLRBackend extends LinuxBackend {
    * the pointer.
    */
   protected getPointerPositionAndWorkAreaSize() {
-    return native.getPointerPositionAndWorkAreaSize();
+    const data = native.getPointerPositionAndWorkAreaSize();
+    if (data.pointerGetTimedOut) {
+      console.error('Pointer get timed out');
+    }
+    return data;
   }
 }

--- a/src/main/backends/linux/wlroots/native/index.ts
+++ b/src/main/backends/linux/wlroots/native/index.ts
@@ -32,6 +32,7 @@ export type Native = {
   getPointerPositionAndWorkAreaSize(): {
     pointerX: number;
     pointerY: number;
+    pointerGetTimedOut: boolean;
     workAreaWidth: number;
     workAreaHeight: number;
   };


### PR DESCRIPTION
Workaround for #1195 as discussed there and on the Kando Discord server.