### PR TITLE
:wrench: Drop `macos-13` & add `macos-14-large` for test deploy

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -90,7 +90,7 @@ jobs:
     name: macOS
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14, macos-14-large]
     runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/electron/forge/issues/2807


### PR DESCRIPTION
> The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.

The CI failed https://github.com/kando-menu/kando/actions/runs/20073186602/job/57580602250?pr=1201 because GitHub Actions dropped macos-13 support.