### PR TITLE
fix: prevent color picker feedback loop during drag

### DIFF
--- a/src/settings-renderer/components/common/ColorButton.tsx
+++ b/src/settings-renderer/components/common/ColorButton.tsx
@@ -35,12 +35,15 @@ type Props = {
  */
 export default function ColorButton(props: Props) {
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+  const [pickerColor, setPickerColor] = React.useState(chroma(props.color).css());
   const [cssColor, setCSSColor] = React.useState(chroma(props.color).css());
   const [inputColor, setInputColor] = React.useState(chroma(props.color).css());
 
   React.useEffect(() => {
-    setCSSColor(chroma(props.color).css());
-    setInputColor(chroma(props.color).css());
+    const color = chroma(props.color).css();
+    setPickerColor(color);
+    setCSSColor(color);
+    setInputColor(color);
   }, [props.color]);
 
   return (
@@ -49,11 +52,12 @@ export default function ColorButton(props: Props) {
         <>
           {props.name ? <div className={classes.popoverHeader}>{props.name}</div> : null}
           <RgbaStringColorPicker
-            color={cssColor}
+            color={pickerColor}
             onChange={(newColor) => {
-              const cssColor = chroma(newColor).css();
-              setCSSColor(cssColor);
-              setInputColor(cssColor);
+              setPickerColor(newColor);
+              const converted = chroma(newColor).css();
+              setCSSColor(converted);
+              setInputColor(converted);
             }}
           />
           <input


### PR DESCRIPTION
Closes #1282

## Problem
When dragging the color picker in Menu Themes settings, the pointer oscillates between two points uncontrollably.

## Cause
The `RgbaStringColorPicker` output was being converted through `chroma-js` and fed back as the `color` prop. The format conversion introduced small rounding differences, creating a feedback loop where the picker position would jump back and forth.

## Fix
Added a separate `pickerColor` state that stores the raw color value from `react-colorful` without `chroma-js` conversion. The converted color is only used for display and output purposes.

### After fix
https://github.com/user-attachments/assets/cba76250-55fb-4bbb-a6b1-c2177ac17ea0