### PR TITLE
feat: Remember the last selected icon theme in the icon picker

### DIFF
--- a/src/settings-renderer/components/common/IconChooserButton.tsx
+++ b/src/settings-renderer/components/common/IconChooserButton.tsx
@@ -57,6 +57,7 @@ type Props = {
  * reopen the icon picker with the same theme when the user opens it again.
  */
 let lastSelectedTheme: string | null = null;
+let lastIconName: string | null = null;
 
 /**
  * A customizable color button component.
@@ -68,11 +69,17 @@ export default function IconChooserButton(props: Props) {
   const [reloadCount, setReloadCount] = React.useState(0);
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const [filterTerm, setFilterTerm] = React.useState('');
-  const [theme, setTheme] = React.useState(lastSelectedTheme || props.theme);
+  const [theme, setTheme] = React.useState(
+    lastIconName === props.icon && lastSelectedTheme ? lastSelectedTheme : props.theme
+  );
 
   React.useEffect(() => {
-    setTheme(lastSelectedTheme || props.theme);
-  }, [props.theme]);
+    if (lastIconName === props.icon && lastSelectedTheme) {
+      setTheme(lastSelectedTheme);
+    } else {
+      setTheme(props.theme);
+    }
+  }, [props.theme, props.icon]);
 
   // Reload the icon pickers when the icon themes are reloaded.
   React.useEffect(() => {
@@ -130,6 +137,7 @@ export default function IconChooserButton(props: Props) {
                 }))}
                 onChange={(newTheme) => {
                   lastSelectedTheme = newTheme;
+                  lastIconName = props.icon;
                   setTheme(newTheme);
                 }}
               />


### PR DESCRIPTION
Fixes #1227

## Description
When setting item icons, the icon picker now remembers the last selected icon theme. Previously, the picker always reset to the item's current theme each time it was opened, requiring users to reselect their preferred theme repeatedly.

## Changes
Added a module-level variable to store the last selected theme in `IconChooserButton.tsx`. The stored theme is used as the initial value when the icon picker is opened.

### Demo

https://github.com/user-attachments/assets/25ce915f-507f-4fb7-bc8a-3e8bc3abaf56