### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,8 +19,8 @@ jobs:
     # Do only run on pushes to the main repository or on pull requests from forks. This avoids running the tests twice on pull requests from the main repository.
     if: (github.event_name == 'push' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -36,8 +36,8 @@ jobs:
     # Do only run on pushes to the main repository or on pull requests from forks. This avoids running the tests twice on pull requests from the main repository.
     if: (github.event_name == 'push' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -53,8 +53,8 @@ jobs:
     # Do only run on pushes to the main repository or on pull requests from forks. This avoids running the tests twice on pull requests from the main repository.
     if: (github.event_name == 'push' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -70,8 +70,8 @@ jobs:
     # Do only run on pushes to the main repository or on pull requests from forks. This avoids running the tests twice on pull requests from the main repository.
     if: (github.event_name == 'push' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -87,6 +87,6 @@ jobs:
     # Do only run on pushes to the main repository or on pull requests from forks. This avoids running the tests twice on pull requests from the main repository.
     if: (github.event_name == 'push' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v4
+        uses: fsfe/reuse-action@3ae3c6bdf1257ab19397fab11fd3312144692083 #v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -57,8 +57,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -79,7 +79,7 @@ jobs:
           }
       - name: Upload Unsigned Artifacts
         id: upload-unsigned-artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: build-${{ matrix.os }}-unsigned
           path: |
@@ -122,8 +122,8 @@ jobs:
     steps:
       # https://github.com/electron/forge/issues/2807
       - run: python3 -m pip install setuptools --break-system-packages
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies

--- a/.github/workflows/deploy_to_winget.yml
+++ b/.github/workflows/deploy_to_winget.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           regex: true
           file: 'Kando-.*x64\.exe'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1.6.0
         id: get-latest-tag

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -19,8 +19,8 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -44,7 +44,7 @@ jobs:
           sudo flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
           sudo tools/make-flatpak-bundle.sh
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: build-${{ matrix.os }}
           path: out/make/**/*
@@ -57,8 +57,8 @@ jobs:
         os: [windows-2022, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -78,7 +78,7 @@ jobs:
             Get-ChildItem -Path out/make/squirrel.windows/*/*.exe | Rename-Item -NewName { $_.BaseName + "-arm64" + $_.Extension }
           }
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: build-${{ matrix.os }}
           path: |
@@ -95,8 +95,8 @@ jobs:
     steps:
       # https://github.com/electron/forge/issues/2807
       - run: python3 -m pip install setuptools --break-system-packages
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
       - name: Install Dependencies
@@ -120,7 +120,7 @@ jobs:
         run: |
           npm run make
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: build-${{ matrix.os }}
           path: |


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `fsfe/reuse-action` from `v4` to `3ae3c6b` in `.github/workflows/checks.yml`
- Pinned `actions/setup-node` from `v4.4.0` to `49933ea` in `.github/workflows/checks.yml`, `.github/workflows/deploy.yml`, `.github/workflows/test_deploy.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/checks.yml`, `.github/workflows/checks.yml`, `.github/workflows/deploy.yml`, `.github/workflows/deploy.yml`, `.github/workflows/deploy_to_winget.yml`, `.github/workflows/deploy_to_winget.yml`, `.github/workflows/test_deploy.yml`, `.github/workflows/test_deploy.yml`
- Pinned `actions/upload-artifact` from `v4` to `ea165f8` in `.github/workflows/deploy.yml`, `.github/workflows/test_deploy.yml`
