### PR TITLE
Fix menu-close animations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 ### :bug: Fixed
 
+- Fixed a regression which caused the animation of menu items to be skipped when closing the menu.
 - Fixed an issue where the color pickers in the settings dialog would glitch out. Thanks to [@Haruto-works333](https://github.com/Haruto-works333) for this contribution!
 - Fixed an issue where Kando would not open a menu on Niri if no pointer device was connected. Thanks to [@make-42](https://github.com/make-42) for fixing this!
 

--- a/src/menu-renderer/index.scss
+++ b/src/menu-renderer/index.scss
@@ -59,8 +59,9 @@ body {
       transition: opacity calc(var(--fade-out-duration) * 0.5) ease;
       transition-delay: calc(var(--fade-out-duration) * 0.5);
     }
+  }
 
-    // We do not want any transitions on the menu nodes while fading in or out.
+  &.no-transitions {
     .menu-node {
       transition: none !important;
     }

--- a/src/menu-renderer/menu.ts
+++ b/src/menu-renderer/menu.ts
@@ -206,11 +206,16 @@ export class Menu extends EventEmitter {
     // arrives and show the menu there. If no mouse enter event arrives within that time,
     // we simply show the menu at the given position.
     const showMenu = () => {
+      this.container.classList.add('no-transitions');
       this.selectItem(
         this.root,
         SelectionSource.eKeyboard,
         this.getInitialMenuPosition()
       );
+      // To ensure that all DOM changes are applied, flush the browser's rendering
+      // pipeline first.
+      this.container.getBoundingClientRect();
+      this.container.classList.remove('no-transitions');
 
       // If required, move the pointer to the center of the menu.
       if (this.settings.warpMouse && this.showMenuOptions.centeredMode) {
@@ -221,9 +226,7 @@ export class Menu extends EventEmitter {
         this.emit('move-pointer', offset);
       }
 
-      // Finally, show the menu. In order to ensure that all DOM changes are applied
-      // before the fade-in animation starts, flush the browser's rendering pipeline first.
-      this.container.getBoundingClientRect();
+      // Finally, show the menu.
       this.container.classList.remove('hidden');
       this.menuShownTime = Date.now();
     };


### PR DESCRIPTION
This fixes a regression which caused the animation of menu items to be skipped when closing the menu.