### PR TITLE
backends: gnome, check if XDG_CURRENT_DESKTOP contains :gnome

### DIFF
--- a/src/main/backends/index.ts
+++ b/src/main/backends/index.ts
@@ -38,10 +38,7 @@ export function getBackend(): Backend | null {
     session = session.toLowerCase();
 
     if (
-      (desktop === 'gnome' ||
-        desktop === 'zorin:gnome' ||
-        desktop === 'unity' ||
-        desktop === 'gnome-classic:gnome') &&
+      (desktop === 'gnome' || desktop === 'unity' || desktop.includes(':gnome')) &&
       session === 'wayland'
     ) {
       // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
Let me know if this change makes sense (not sure if you want an allow-list approach for all desktops based on gnome)

I'm making this change because I was hoping to test the Flatpak on a `Phosh:GNOME` phone.

The phone is running postmarketOS which uses musl and would be a pain to run this app outside of the Flatpak (so I haven't tested this on the phone in question).