### PR TITLE
Intercept window closing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,7 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 ### :bug: Fixed
 
 - A regression which caused the animation of menu items to be skipped when closing the menu.
+- A bug which would make it impossible to open a menu until Kando was restarted after a menu got closed by the window manager (e.g. by pressing <kbd>Alt</kbd>+<kbd>F4</kbd>).
 - An issue where the color pickers in the settings dialog would glitch out. Thanks to [@Haruto-works333](https://github.com/Haruto-works333) for this contribution!
 - An issue which prevent the menu to open on Niri if no windows were open. Thanks to [@AurelienJt](https://github.com/AurelienJt) for this fix!
 - An issue where Kando would not open a menu on Niri if no pointer device was connected. Thanks to [@make-42](https://github.com/make-42) for fixing this!

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -514,6 +514,12 @@ export class KandoApp {
       },
     });
     await this.menuWindow.load();
+
+    // Make sure that closing the menu window just hides it instead of actually closing it.
+    this.menuWindow.on('close', (event) => {
+      event.preventDefault();
+      this.menuWindow.hide();
+    });
   }
 
   /**


### PR DESCRIPTION
This fixes a bug which would make it impossible to open a menu until Kando was restarted after a menu got closed by the window manager (e.g. by pressing <kbd>Alt</kbd>+<kbd>F4</kbd>).