### PR TITLE
Use title window property on Hyprland

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,8 +35,9 @@ This changelog follows the rules of [Keep a Changelog](http://keepachangelog.com
 
 ### :wrench: Changed
 
+- **:collision: The Hyprland backend** now uses the `title` property of windows in addition to the `initialTitle` property. With this change, you can now make menus which only show up for windows with dynamic titles (e.g. a terminal showing the current directory in the title, or a browser showing the current page title). It considers the window's name now to be **_initialTitle_ - _title_**. If you used window-name conditions in your menus, you may have to update them to match the new window name format.
+- **The GNOME Wayland backend** is now used if `XDG_CURRENT_DESKTOP` contains ":gnome" instead of checking for a hard-coded list of GNOME versions. This should make it more robust and compatible with more desktop environments which identify themselves as GNOME-compatible. Thanks to [@radmorecameron](https://github.com/radmorecameron) for this contribution!
 - The icon-picker dialog will now remember the last selected icon theme if you closed it by accident. Before, it would always reset to the currently selected icon theme which could be quite annoying. Thanks to [@Haruto-works333](https://github.com/Haruto-works333) for this contribution!
-- The GNOME Wayland backend is now used if `XDG_CURRENT_DESKTOP` contains ":gnome" instead of checking for a hard-coded list of GNOME versions. This should make it more robust and compatible with more desktop environments which identify themselves as GNOME-compatible. Thanks to [@radmorecameron](https://github.com/radmorecameron) for this contribution!
 - Upgraded many dependencies to their latest versions. This includes an upgrade to Electron 40 which uses Wayland natively now on Linux. Feel free to report any issues you encounter!
 - Pinned all GitHub Actions to specific commit SHAs to increase the security of the build process. Thanks to [@pgoslatara](https://github.com/pgoslatara) for this contribution!
 

--- a/src/main/backends/linux/hyprland/backend.ts
+++ b/src/main/backends/linux/hyprland/backend.ts
@@ -81,7 +81,8 @@ for more information.
       ]);
 
       return {
-        windowName: activewindow['initialTitle'] || '',
+        windowName:
+          (activewindow['initialTitle'] || '') + ' - ' + (activewindow['title'] || ''),
         appName: activewindow['initialClass'] || '',
         pointerX: cursorpos['x'],
         pointerY: cursorpos['y'],


### PR DESCRIPTION
The Hyprland backend now uses the `title` property of windows in addition to the `initialTitle` property. With this change, you can now make menus which only show up for windows with dynamic titles (e.g. a terminal showing the current directory in the title, or a browser showing the current page title). It considers the window's name now to be **_initialTitle_ - _title_**. If you used window-name conditions in your menus, you may have to update them to match the new window name format.