### PR TITLE
chore: improve kando maintenance path

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -156,8 +156,10 @@ try {
       fs.mkdirSync(path.join(getConfigDirectory(), dir), { recursive: true });
     });
   } catch (error) {
+    const errorCode =
+      error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
     if (
-      (error.code === 'EROFS' || error.code === 'EACCES' || error.code === 'EPERM') &&
+      (errorCode === 'EROFS' || errorCode === 'EACCES' || errorCode === 'EPERM') &&
       !generalSettings.get('ignoreWriteProtectedConfigFiles')
     ) {
       console.log('Failed to create the themes folders due to write-protected files.');

--- a/test/math.spec.ts
+++ b/test/math.spec.ts
@@ -48,6 +48,12 @@ describe('normalize', () => {
       y: -0.7071067811865475,
     });
   });
+
+  it('should return NaN for zero-length vectors', () => {
+    const result = normalize({ x: 0, y: 0 });
+    expect(result.x).to.be.NaN;
+    expect(result.y).to.be.NaN;
+  });
 });
 
 describe('getClosestEquivalentAngle', () => {


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in src/main/index.ts, test/math.spec.ts related to TypeScript, frontend tooling, test stability, build fixes; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.