### PR TITLE
fix: propagate desktop portal request errors to avoid startup hang on  KDE Wayland

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,7 @@ The [Unreleased] section contains changes which are not released yet. If you wan
 
 ### :bug: Fixed
 
+- A bug which could prevent Kando from starting up on KDE Wayland. If a desktop portal request failed (for instance the global-shortcuts portal returning "An app id is required"), the error was not propagated and Kando would hang during initialization instead of falling back gracefully.
 - Selecting menu items with the numpad keys. They now work the same as the normal number keys. Thanks to [@username1419](https://github.com/username1419) for this fix!
 
 ### :fire: Removed

--- a/src/main/backends/linux/portals/desktop-portal.ts
+++ b/src/main/backends/linux/portals/desktop-portal.ts
@@ -50,12 +50,13 @@ export class DesktopPortal extends EventEmitter {
    *
    * @param method This will be called when the request is ready to be dispatched. A
    *   request token is given to this method, this is usually required for the options
-   *   vardict of the actual request method.
+   *   vardict of the actual request method. The method should return the promise of the
+   *   underlying D-Bus call so that errors can be propagated.
    * @returns A promise which resolves when the request has been processed.
    * @see https://flatpak.github.io/xdg-desktop-portal/#idm9
    */
   protected async makeRequest(
-    method: (request: { token: string; path: string }) => void
+    method: (request: { token: string; path: string }) => Promise<unknown> | void
   ) {
     return new Promise<DBus.Message>((resolve, reject) => {
       const request = this.generateToken('request');
@@ -73,7 +74,13 @@ export class DesktopPortal extends EventEmitter {
 
       this.bus.addListener('message', responseListener);
 
-      method(request);
+      // If the D-Bus call itself fails (for instance because the portal returns an error
+      // instead of replying with a Response signal), we have to reject the promise here.
+      // Otherwise it would never resolve and the unhandled rejection would crash the app.
+      Promise.resolve(method(request)).catch((error) => {
+        this.bus.removeListener('message', responseListener);
+        reject(error);
+      });
     });
   }
 

--- a/src/main/backends/linux/portals/global-shortcuts.ts
+++ b/src/main/backends/linux/portals/global-shortcuts.ts
@@ -79,7 +79,7 @@ export class GlobalShortcuts extends DesktopPortal {
 
     if (this.interface) {
       const result = await this.makeRequest((request) => {
-        this.interface.ListShortcuts(this.session.path, {
+        return this.interface.ListShortcuts(this.session.path, {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           handle_token: new DBus.Variant('s', request.token),
         });
@@ -110,7 +110,7 @@ export class GlobalShortcuts extends DesktopPortal {
 
     if (this.interface) {
       await this.makeRequest((request) => {
-        this.interface.BindShortcuts(
+        return this.interface.BindShortcuts(
           this.session.path,
           shortcuts.map((shortcut) => [
             shortcut.id,
@@ -181,7 +181,7 @@ export class GlobalShortcuts extends DesktopPortal {
    */
   private async createSession() {
     return this.makeRequest((request) => {
-      this.interface.CreateSession({
+      return this.interface.CreateSession({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/main/backends/linux/portals/remote-desktop.ts
+++ b/src/main/backends/linux/portals/remote-desktop.ts
@@ -144,7 +144,7 @@ export class RemoteDesktop extends DesktopPortal {
    */
   private async createSession() {
     return this.makeRequest((request) => {
-      this.interface.CreateSession({
+      return this.interface.CreateSession({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -186,7 +186,7 @@ export class RemoteDesktop extends DesktopPortal {
         // Ignore errors.
       }
 
-      this.interface.SelectDevices(this.session.path, options);
+      return this.interface.SelectDevices(this.session.path, options);
     });
   }
 
@@ -198,7 +198,7 @@ export class RemoteDesktop extends DesktopPortal {
    */
   private async start() {
     return this.makeRequest((request) => {
-      this.interface.Start(this.session.path, '', {
+      return this.interface.Start(this.session.path, '', {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         handle_token: new DBus.Variant('s', request.token),
       });


### PR DESCRIPTION
**Problem**

On KDE Plasma Wayland, Kando fails to start. xdg-desktop-portal-kde rejects the global-shortcuts CreateSession call with DBusError: An app id is required, producing an unhandled promise rejection and hanging the app during initialization:

(node:13350) UnhandledPromiseRejectionWarning: DBusError: An app id is required

**Root cause**

In makeRequest (desktop-portal.ts), the callback fired the D-Bus call (e.g. CreateSession) but ignored the returned promise. When the portal rejected instead of replying with a Response signal, the error was never propagated — so makeRequest waited forever, hanging isAvailable() → init() and never opening the window. The try/catch in connectImpl meant to handle this never got the chance to fire.

**Fix**

- makeRequest now propagates the underlying D-Bus call's rejection (and removes its message listener) instead of waiting indefinitely.
- The portal callbacks in global-shortcuts.ts and remote-desktop.ts now return their D-Bus call promises so rejections reach makeRequest.

With this, a failed portal request rejects cleanly, connectImpl's catch runs, and the KDE backend falls back to its KWin-scripting method as intended — the app starts normally.

**Testing**

- npm run tscheck, eslint, and prettier all pass.
- Verified Kando launches on KDE Plasma Wayland.

**Related issue**
#1412 