### PR TITLE
Fix zh-TW locale fallback to zh-Hant

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -224,6 +224,7 @@ try {
           'de-CH': ['de', 'en'],
           'de-AT': ['de', 'en'],
           'zh-CN': ['zh-Hans', 'en'],
+          'zh-TW': ['zh-Hant', 'en'],
           zh: ['zh-Hans', 'en'],
           pt: ['pt-BR', 'en'],
           /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
When testing the 3.0 version, I noticed that Kando does not correctly use `zh-Hant` on systems with the `zh-TW` locale when the Language option is set to "Use system language".

Instead, it falls back through `zh: ['zh-Hans', 'en']` and loads the `zh-Hans` translation.

This issue can be reproduced in both a GNOME environment and a Windows virtual machine. The current stable version 2.3.1 is also affected.

This PR adds the missing `'zh-TW': ['zh-Hant', 'en']` fallback rule, so systems using the `zh-TW` locale will correctly display the existing `zh-Hant` interface after a fresh Kando installation.

I ran `npm start` with a fresh configuration and confirmed that Kando correctly displays the `zh-Hant` interface on my system.

I am still learning the Git workflow, so please feel free to point out anything I may have missed or done incorrectly. 😅