### PR TITLE
:wrench: Use macOS key symbol for displaying shortcuts

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,6 +11,7 @@
 export * from './settings-schemata';
 export * from './typed-event-emitter';
 export * from './action-type-registry';
+export * from './shortcut';
 
 import { AchievementStats, Menu } from './settings-schemata';
 

--- a/src/common/shortcut.ts
+++ b/src/common/shortcut.ts
@@ -1,0 +1,43 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+const MAC_MODIFIER_SYMBOLS = new Map([
+  ['Command', '⌘'],
+  ['Cmd', '⌘'],
+  ['CommandOrControl', '⌘'],
+  ['CmdOrCtrl', '⌘'],
+  ['Meta', '⌘'],
+  ['Option', '⌥'],
+  ['Alt', '⌥'],
+  ['Control', '⌃'],
+  ['Ctrl', '⌃'],
+  ['Shift', '⇧'],
+]);
+
+/**
+ * Formats a shortcut for display without changing the accelerator used for binding it.
+ *
+ * @param shortcut The accelerator string to format.
+ * @param useMacSymbols Whether macOS keyboard symbols should be used.
+ * @returns The formatted shortcut.
+ */
+export function formatShortcutForDisplay(
+  shortcut: string,
+  useMacSymbols: boolean
+): string {
+  if (!useMacSymbols) {
+    return shortcut;
+  }
+
+  return shortcut
+    .split('+')
+    .map((part) => MAC_MODIFIER_SYMBOLS.get(part) || part)
+    .join('');
+}

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -39,6 +39,7 @@ import {
   SystemInfo,
   VersionInfo,
   RootMenuItem,
+  formatShortcutForDisplay,
 } from '../common';
 import {
   Settings,
@@ -1308,10 +1309,11 @@ export class KandoApp {
 
     // Add an entry for each menu.
     for (const menu of this.menuSettings.get('menus')) {
-      const trigger =
-        (this.backend.getBackendInfo().supportsShortcuts
-          ? menu.shortcut
-          : menu.shortcutID) || i18next.t('settings.not-bound');
+      const supportsShortcuts = this.backend.getBackendInfo().supportsShortcuts;
+      const shortcut = supportsShortcuts
+        ? formatShortcutForDisplay(menu.shortcut, process.platform === 'darwin')
+        : menu.shortcutID;
+      const trigger = shortcut || i18next.t('settings.not-bound');
       template.push({
         label: `${menu.root.name} (${trigger})`,
         click: () => {

--- a/src/settings-renderer/components/common/ShortcutPicker.tsx
+++ b/src/settings-renderer/components/common/ShortcutPicker.tsx
@@ -15,10 +15,18 @@ import classNames from 'classnames/bind';
 
 import { fixKeyCodeCase, isKnownKeyCode } from '../../../common/key-codes';
 import KeyMapper from '../../../common/key-mapper';
+import { formatShortcutForDisplay } from '../../../common/shortcut';
 import { Button, SettingsRow } from '.';
 
 import * as classes from './ShortcutPicker.module.scss';
 const cx = classNames.bind(classes);
+
+const MAC_MODIFIER_NAMES = new Map([
+  ['⌘', 'Command'],
+  ['⌥', 'Option'],
+  ['⌃', 'Control'],
+  ['⇧', 'Shift'],
+]);
 
 type Props = {
   /**
@@ -83,20 +91,25 @@ type Props = {
  * @returns A React component that allows the user to enter a shortcut.
  */
 export default function ShortcutPicker(props: Props) {
-  const [shortcut, setShortcut] = React.useState(props.initialValue);
-  const [recording, setRecording] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  // Update the value when the initialValue prop changes. This is necessary because the
-  // initialValue prop might change after the component has been initialized.
-  React.useEffect(() => setShortcut(props.initialValue), [props.initialValue]);
-
   // Depending on the mode, we use different implementations for recording the input.
   const impl = React.useMemo(() => {
     return props.mode === 'key-names'
       ? new KeyNameImpl(props.useModifiers)
       : new KeyCodeImpl(props.useModifiers);
   }, [props.mode, props.useModifiers]);
+
+  const [shortcut, setShortcut] = React.useState(() =>
+    impl.normalizeInput(props.initialValue)
+  );
+  const [recording, setRecording] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Update the value when the initialValue prop changes. This is necessary because the
+  // initialValue prop might change after the component has been initialized.
+  React.useEffect(
+    () => setShortcut(impl.normalizeInput(props.initialValue)),
+    [impl, props.initialValue]
+  );
 
   // This method checks if the given hotkey is valid. A hotkey is valid if it contains
   // exactly one key and any number of modifier keys. The key and modifier keys must be
@@ -146,7 +159,7 @@ export default function ShortcutPicker(props: Props) {
           spellCheck="false"
           style={!props.isGrowing ? { maxWidth: '100px' } : undefined}
           type="text"
-          value={shortcut}
+          value={impl.formatInput(shortcut)}
           onBlur={(event) => {
             // If the user clicked the record button, the next focused element is the
             // button. In this case, we ignore this event and handle stopping the
@@ -155,14 +168,14 @@ export default function ShortcutPicker(props: Props) {
               return;
             }
 
-            const newShortcut = event.currentTarget.value;
+            const newShortcut = impl.normalizeInput(event.currentTarget.value);
 
             // If we were not recording, it is allowed that the shortcut is empty. In this
             // case the shortcut was unbound.
             if ((newShortcut || !recording) && isValid(newShortcut)) {
               props.onChange?.(newShortcut);
             } else {
-              setShortcut(props.initialValue);
+              setShortcut(impl.normalizeInput(props.initialValue));
               props.onChange?.(props.initialValue);
             }
 
@@ -191,7 +204,7 @@ export default function ShortcutPicker(props: Props) {
               const isComplete = impl.recordInput(event);
               if (isComplete) {
                 setRecording(false);
-                setShortcut(event.currentTarget.value);
+                setShortcut(impl.normalizeInput(event.currentTarget.value));
                 event.currentTarget.blur();
               }
               event.preventDefault();
@@ -212,7 +225,7 @@ export default function ShortcutPicker(props: Props) {
               if (shortcut && isValid(shortcut)) {
                 props.onChange?.(shortcut);
               } else {
-                setShortcut(props.initialValue);
+                setShortcut(impl.normalizeInput(props.initialValue));
                 props.onChange?.(props.initialValue);
               }
             }
@@ -250,7 +263,9 @@ class KeyNameImpl {
    * @returns True if the shortcut is complete, false otherwise.
    */
   public recordInput(event: React.KeyboardEvent<HTMLInputElement>) {
-    const parts = event.currentTarget.value.split('+').filter((part) => part !== '');
+    const parts = this.normalizeInput(event.currentTarget.value)
+      .split('+')
+      .filter((part) => part !== '');
 
     const push = (part: string) => {
       if (!parts.includes(part)) {
@@ -268,11 +283,11 @@ class KeyNameImpl {
       }
 
       if (event.altKey) {
-        push('Alt');
+        push(cIsMac ? 'Option' : 'Alt');
       }
 
       if (event.metaKey) {
-        push('Meta');
+        push(cIsMac ? 'Command' : 'Meta');
       }
     }
 
@@ -287,9 +302,34 @@ class KeyNameImpl {
       parts.push(key);
     }
 
-    event.currentTarget.value = parts.join('+');
+    event.currentTarget.value = this.formatInput(parts.join('+'));
 
     return isComplete;
+  }
+
+  /**
+   * This method formats a shortcut for display. On macOS, modifier names are replaced
+   * with the standard keyboard symbols while the stored accelerator remains unchanged.
+   *
+   * @param shortcut The normalized shortcut to format.
+   * @returns The shortcut as it should be displayed in the input field.
+   */
+  public formatInput(shortcut: string): string {
+    if (!cIsMac) {
+      return shortcut;
+    }
+
+    const parts = shortcut.split('+');
+    const keyCount = parts.filter((part) => this.isValidKey(part)).length;
+    const canUseSymbols =
+      keyCount <= 1 &&
+      parts.every((part) => this.isValidModifier(part) || this.isValidKey(part));
+
+    if (!canUseSymbols) {
+      return shortcut;
+    }
+
+    return formatShortcutForDisplay(shortcut, true);
   }
 
   /**
@@ -301,6 +341,17 @@ class KeyNameImpl {
    * @returns The normalized shortcut.
    */
   public normalizeInput(shortcut: string): string {
+    // Accept the standard macOS keyboard symbols used by formatInput().
+    if (cIsMac) {
+      for (const [symbol, name] of MAC_MODIFIER_NAMES) {
+        shortcut = shortcut.split(symbol).join(`${name}+`);
+      }
+
+      // A user may type a separator after a symbol even though the formatted value does
+      // not contain one.
+      shortcut = shortcut.replace(/\++/g, '+');
+    }
+
     // We first remove any whitespace and transform the shortcut to lowercase.
     shortcut = shortcut.replace(/\s/g, '').toLowerCase();
 
@@ -342,6 +393,17 @@ class KeyNameImpl {
     ]);
 
     parts = parts.map((part) => shorthands.get(part) || part);
+
+    // Use the native macOS modifier names in the settings UI. Electron accepts both
+    // variants, but Option and Command are less confusing to macOS users.
+    if (cIsMac) {
+      const macModifiers = new Map([
+        ['Alt', 'Option'],
+        ['Meta', 'Command'],
+      ]);
+
+      parts = parts.map((part) => macModifiers.get(part) || part);
+    }
 
     return parts.join('+');
   }
@@ -416,6 +478,17 @@ class KeyCodeImpl {
     event.currentTarget.value = parts.join('+');
 
     return this.isValidKey(event.code);
+  }
+
+  /**
+   * Key codes describe physical keys, so they should be displayed without
+   * platform-specific substitutions.
+   *
+   * @param shortcut The shortcut to format.
+   * @returns The unchanged shortcut.
+   */
+  public formatInput(shortcut: string): string {
+    return shortcut;
   }
 
   /**

--- a/src/settings-renderer/components/menu-list/MenuList.tsx
+++ b/src/settings-renderer/components/menu-list/MenuList.tsx
@@ -25,6 +25,7 @@ import { useAppState, useMenuSettings, useMappedMenuProperties } from '../../sta
 import { Scrollbox, ThemedIcon, Swirl, Note, Button } from '../common';
 import CollectionDetails from './CollectionDetails';
 import { ensureUniqueKeys } from '../../utils';
+import { formatShortcutForDisplay } from '../../../common/shortcut';
 
 /** For rendering the menus, a list of these objects is created. */
 type RenderedMenu = {
@@ -90,9 +91,10 @@ export default function MenuList() {
   // We will compile a list of all menus which are currently visible. We will use a list
   // of IRenderedMenu objects for this.
   let renderedMenus = menus.map((menu, index) => {
-    const shortcut =
-      (backend.supportsShortcuts ? menu.shortcut : menu.shortcutID) ||
-      i18next.t('settings.not-bound');
+    const configuredShortcut = backend.supportsShortcuts
+      ? formatShortcutForDisplay(menu.shortcut, cIsMac)
+      : menu.shortcutID;
+    const shortcut = configuredShortcut || i18next.t('settings.not-bound');
     const renderedMenu: RenderedMenu = {
       key: menu.name + menu.icon + menu.iconTheme + shortcut,
       index,

--- a/test/shortcut.spec.ts
+++ b/test/shortcut.spec.ts
@@ -1,0 +1,30 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: MIT
+
+import { expect } from 'chai';
+
+import { formatShortcutForDisplay } from '../src/common';
+
+describe('formatShortcutForDisplay', () => {
+  it('should use native symbols for macOS modifiers', () => {
+    expect(formatShortcutForDisplay('Control+Option+Command+Shift+A', true)).to.equal(
+      '⌃⌥⌘⇧A'
+    );
+  });
+
+  it('should normalize accelerator modifier aliases for display', () => {
+    expect(formatShortcutForDisplay('Ctrl+Alt+Meta+Space', true)).to.equal('⌃⌥⌘Space');
+    expect(formatShortcutForDisplay('CmdOrCtrl+P', true)).to.equal('⌘P');
+  });
+
+  it('should leave shortcuts unchanged on other platforms', () => {
+    expect(formatShortcutForDisplay('Control+Alt+A', false)).to.equal('Control+Alt+A');
+  });
+});


### PR DESCRIPTION
Previously, Kando in macOS displayed Option as Alt and Command as Meta, which may have confused Mac users because Alt and Meta do not exist in macOS. In this PR, I changed the macOS buttons to more easily recognizable icons, and macOS itself does the same.

### Difference

| Area | Before | After |
|---|---|---|
| macOS shortcut recording | Option was displayed as `Alt`; Command was displayed as `Meta` | Option is displayed as `⌥`; Command is displayed as `⌘` |
| Other modifiers | Displayed as full names such as `Control` and `Shift` | Displayed as `⌃` and `⇧` on macOS |
| Example | `Control+Option+Command+Shift+A` | `⌃⌥⌘⇧A` |
| Shortcut input | Used verbose Electron accelerator names | Uses native macOS keyboard symbols |
| Menu bar dropdown | Displayed shortcuts as verbose text | Uses the same native macOS symbols |
| Stored configuration | Electron accelerator names | Unchanged; symbols are display-only |
| Other platforms | Existing shortcut formatting | Unchanged |

### Preview

|macOS itself|Kando settings|Kando menu bar|
|:-:|:-:|:-:|
|<img width="451" height="123" alt="image" src="https://github.com/user-attachments/assets/1d31a727-4ff0-4c6b-b5d6-104db3da001c" />|<img width="360" height="100" alt="dyn-acd1b67b8be249a3c0415869fb7979cd" src="https://github.com/user-attachments/assets/4e823e8e-b343-43da-b897-66be7d9fdfe7" />|<img width="322" height="174" alt="image" src="https://github.com/user-attachments/assets/f3078489-7edc-44b2-b5bb-adf7770453c8" />|