### PR TITLE
:bug: Fixed KDE shortcut regression on 6.7.4

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,6 +71,7 @@ The [Unreleased] section contains changes which are not released yet. If you wan
 - Selecting menu items with the numpad keys. They now work the same as the normal number keys. Thanks to [@username1419](https://github.com/username1419) for this fix!
 - A bug which caused the center text to not be drawn properly if the quick-select key of the item was a character which has special meaning in regular expressions. Thanks to [@GZ0759](https://github.com/GZ0759) for this fix!
 - An issue which caused the menu window to be wrongly sized and positioned on KDE Wayland with some screen configurations.
+- A regression on KDE Wayland 6.7.4 which would cause global shortcuts to not work after Kando was started.
 
 ### :fire: Removed
 

--- a/src/main/backends/linux/kde/wayland/backend.ts
+++ b/src/main/backends/linux/kde/wayland/backend.ts
@@ -243,19 +243,11 @@ export class KDEWaylandBackend extends LinuxBackend {
       return;
     }
 
-    // Check if any of the currentShortcuts are new. If they are, we bind them via the portal.
-    const oldShortcuts = await this.globalShortcuts.listShortcuts();
-    const hasNewShortcut = currentShortcuts.some(
-      (shortcut) => !oldShortcuts.includes(shortcut)
+    this.globalShortcuts.bindShortcuts(
+      currentShortcuts.map((shortcut) => {
+        return { id: shortcut, description: shortcut };
+      })
     );
-
-    if (hasNewShortcut) {
-      this.globalShortcuts.bindShortcuts(
-        currentShortcuts.map((shortcut) => {
-          return { id: shortcut, description: shortcut };
-        })
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
In KWin 6.7.4, the behavior of the global-shortcuts portal changed a bit, resulting in Kando not properly rebinding shortcuts on startup.