### PR TITLE
:tada: Remember settings window geometry

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ The [Unreleased] section contains changes which are not released yet. If you wan
 
 ### :tada: Added
 
+- Kando now remembers the size, position, and maximized state of the settings window.
 - **Workflows!** Instead of fixed item types, we have now various _actions_ which can be combined in flexible ways. We only have two menu item types now: submenus and leaf items, called buttons. Buttons offer two workflows which can be filled with any number of actions:
   - The hover-workflow gets executed when you mouse-over the item. The default menu items do not use this, but you could put actions into this if you want.
   - The select-workflow gets triggered when you click the item. This usually contains two actions: first something like open-url, execute-command, or simulate-shortcut. And then: close-menu. You can reorder the actions to first close the menu and then execute the other action! Or decide not to close the menu at all...

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,8 @@ The [Unreleased] section contains changes which are not released yet. If you wan
 
 ### :tada: Added
 
-- Kando now remembers the size, position, and maximized state of the settings window.
+- Kando now remembers the size, position, maximized state, and sidebar widths of the
+  settings window.
 - **Workflows!** Instead of fixed item types, we have now various _actions_ which can be combined in flexible ways. We only have two menu item types now: submenus and leaf items, called buttons. Buttons offer two workflows which can be filled with any number of actions:
   - The hover-workflow gets executed when you mouse-over the item. The default menu items do not use this, but you could put actions into this if you want.
   - The select-workflow gets triggered when you click the item. This usually contains two actions: first something like open-url, execute-command, or simulate-shortcut. And then: close-menu. You can reorder the actions to first close the menu and then execute the other action! Or decide not to close the menu at all...

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -134,6 +134,12 @@ export type SystemInfo = {
   readonly ipcApiVersion: number;
 };
 
+/** The persisted widths of the resizable sidebars in the settings window. */
+export type SettingsWindowSidebarWidths = {
+  readonly left?: number;
+  readonly right?: number;
+};
+
 /** This type describes a icon theme consisting of a collection of icon files. */
 export type FileIconThemeDescription = {
   /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -307,6 +307,7 @@ export class KandoApp {
     this.isQuitting = true;
 
     this.menuWindow?.destroy();
+    this.settingsWindow?.saveState();
     this.settingsWindow?.destroy();
 
     if (this.backend != null) {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -568,6 +568,19 @@ export class KandoApp {
       } as SystemInfo;
     });
 
+    // Allow the renderer to restore and persist the widths of its resizable sidebars.
+    ipcMain.handle('settings-window.get-sidebar-widths', () => {
+      return this.settingsWindow?.getSidebarWidths() ?? {};
+    });
+    ipcMain.on(
+      'settings-window.set-sidebar-width',
+      (_event, position: unknown, width: unknown) => {
+        if ((position === 'left' || position === 'right') && typeof width === 'number') {
+          this.settingsWindow?.setSidebarWidth(position, width);
+        }
+      }
+    );
+
     // This should return the index of the currently selected menu. For now, we just
     // return the index of a menu with the same name as the last menu. If the user uses
     // the same name for multiple menus, this will not work as expected.

--- a/src/main/settings-window.ts
+++ b/src/main/settings-window.ts
@@ -9,10 +9,15 @@
 // SPDX-License-Identifier: MIT
 
 import os from 'node:os';
-import { BrowserWindow, shell, ipcMain } from 'electron';
+import { BrowserWindow, shell, ipcMain, screen } from 'electron';
 
 import { GeneralSettings } from '../common';
-import { Settings } from './settings';
+import {
+  Settings,
+  SettingsWindowStateStore,
+  fitWindowBoundsToWorkArea,
+  getConfigDirectory,
+} from './settings';
 import { Backend } from './backends';
 import { WindowsBackend } from './backends/windows/backend';
 
@@ -21,6 +26,9 @@ declare const SETTINGS_WINDOW_WEBPACK_ENTRY: string;
 
 /** This is window which contains the settings of Kando. */
 export class SettingsWindow extends BrowserWindow {
+  /** Stores the size, position, and maximized state independently of user settings. */
+  private readonly stateStore: SettingsWindowStateStore;
+
   /** This will resolve once the window has fully loaded. */
   public onWindowLoaded = new Promise<void>((resolve) => {
     ipcMain.on('settings-window.ready', () => {
@@ -29,6 +37,15 @@ export class SettingsWindow extends BrowserWindow {
   });
 
   constructor(backend: Backend, settings: Settings<GeneralSettings>) {
+    const stateStore = new SettingsWindowStateStore(getConfigDirectory());
+    const windowState = stateStore.load();
+    const restoredBounds = windowState.bounds
+      ? fitWindowBoundsToWorkArea(
+          windowState.bounds,
+          screen.getDisplayMatching(windowState.bounds).workArea
+        )
+      : undefined;
+
     // The special 'auto' flavor is only used as an initial default value. We override it
     // with the preferred flavor of the backend.
     if (settings.get('settingsWindowFlavor') === 'auto') {
@@ -72,13 +89,21 @@ export class SettingsWindow extends BrowserWindow {
       // For Windows.
       backgroundMaterial: transparent ? 'acrylic' : undefined,
       fullscreenable: false,
-      width: 1350,
-      height: 900,
+      x: restoredBounds?.x,
+      y: restoredBounds?.y,
+      width: restoredBounds?.width ?? 1350,
+      height: restoredBounds?.height ?? 900,
       minWidth: 1000,
       minHeight: 700,
       show: false,
       autoHideMenuBar: true,
     });
+
+    this.stateStore = stateStore;
+
+    // Persist the normal bounds so that closing a maximized window does not replace the
+    // user's preferred normal size with the display-sized maximized bounds.
+    this.on('close', () => this.saveState());
 
     // Due to an Electron issue, the acrylic effect on Windows is broken after maximizing
     // the window (https://github.com/electron/electron/issues/42393). We can fix this by
@@ -98,6 +123,28 @@ export class SettingsWindow extends BrowserWindow {
     this.loadURL(SETTINGS_WINDOW_WEBPACK_ENTRY);
 
     // Show the window when the renderer is ready.
-    this.onWindowLoaded.then(() => this.show());
+    this.onWindowLoaded.then(() => {
+      if (this.isDestroyed()) {
+        return;
+      }
+
+      if (windowState.maximized) {
+        this.maximize();
+      }
+
+      this.show();
+    });
+  }
+
+  /** Persists the current normal bounds and maximized state. */
+  public saveState() {
+    if (this.isDestroyed()) {
+      return;
+    }
+
+    this.stateStore.save({
+      bounds: this.getNormalBounds(),
+      maximized: this.isMaximized(),
+    });
   }
 }

--- a/src/main/settings-window.ts
+++ b/src/main/settings-window.ts
@@ -11,9 +11,10 @@
 import os from 'node:os';
 import { BrowserWindow, shell, ipcMain, screen } from 'electron';
 
-import { GeneralSettings } from '../common';
+import { GeneralSettings, SettingsWindowSidebarWidths } from '../common';
 import {
   Settings,
+  SettingsWindowState,
   SettingsWindowStateStore,
   fitWindowBoundsToWorkArea,
   getConfigDirectory,
@@ -26,8 +27,11 @@ declare const SETTINGS_WINDOW_WEBPACK_ENTRY: string;
 
 /** This is window which contains the settings of Kando. */
 export class SettingsWindow extends BrowserWindow {
-  /** Stores the size, position, and maximized state independently of user settings. */
+  /** Stores window geometry and sidebar widths independently of user settings. */
   private readonly stateStore: SettingsWindowStateStore;
+
+  /** The current machine-local state of this settings window. */
+  private state: SettingsWindowState;
 
   /** This will resolve once the window has fully loaded. */
   public onWindowLoaded = new Promise<void>((resolve) => {
@@ -100,6 +104,7 @@ export class SettingsWindow extends BrowserWindow {
     });
 
     this.stateStore = stateStore;
+    this.state = windowState;
 
     // Persist the normal bounds so that closing a maximized window does not replace the
     // user's preferred normal size with the display-sized maximized bounds.
@@ -142,9 +147,33 @@ export class SettingsWindow extends BrowserWindow {
       return;
     }
 
-    this.stateStore.save({
+    this.state = {
+      ...this.state,
       bounds: this.getNormalBounds(),
       maximized: this.isMaximized(),
-    });
+    };
+    this.stateStore.save(this.state);
+  }
+
+  /** Returns the persisted widths of the settings window sidebars. */
+  public getSidebarWidths(): SettingsWindowSidebarWidths {
+    return { ...this.state.sidebarWidths };
+  }
+
+  /** Persists the width of one settings window sidebar. */
+  public setSidebarWidth(position: 'left' | 'right', width: number) {
+    const roundedWidth = Math.round(width);
+    if (!Number.isFinite(roundedWidth) || roundedWidth <= 0) {
+      return;
+    }
+
+    this.state = {
+      ...this.state,
+      sidebarWidths: {
+        ...this.state.sidebarWidths,
+        [position]: roundedWidth,
+      },
+    };
+    this.saveState();
   }
 }

--- a/src/main/settings/index.ts
+++ b/src/main/settings/index.ts
@@ -11,6 +11,7 @@
 export * from './general-settings';
 export * from './menu-settings';
 export * from './settings';
+export * from './settings-window-state';
 
 import { app } from 'electron';
 import fs from 'fs-extra';

--- a/src/main/settings/settings-window-state.ts
+++ b/src/main/settings/settings-window-state.ts
@@ -23,6 +23,12 @@ const SETTINGS_WINDOW_STATE_SCHEMA = z.object({
     })
     .optional(),
   maximized: z.boolean().default(false),
+  sidebarWidths: z
+    .object({
+      left: z.number().int().positive().optional(),
+      right: z.number().int().positive().optional(),
+    })
+    .optional(),
 });
 
 /** The machine-local state of the settings window. */

--- a/src/main/settings/settings-window-state.ts
+++ b/src/main/settings/settings-window-state.ts
@@ -1,0 +1,97 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Morax <james20081204@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import fs from 'fs-extra';
+import path from 'node:path';
+import type { Rectangle } from 'electron';
+import * as z from 'zod';
+
+const SETTINGS_WINDOW_STATE_SCHEMA = z.object({
+  bounds: z
+    .object({
+      x: z.number().int(),
+      y: z.number().int(),
+      width: z.number().int().positive(),
+      height: z.number().int().positive(),
+    })
+    .optional(),
+  maximized: z.boolean().default(false),
+});
+
+/** The machine-local state of the settings window. */
+export type SettingsWindowState = z.infer<typeof SETTINGS_WINDOW_STATE_SCHEMA>;
+
+/**
+ * Fits the given window bounds into a display's work area. This keeps a restored window
+ * reachable after a display was disconnected or its resolution changed.
+ *
+ * @param bounds The bounds which were persisted for the window.
+ * @param workArea The work area of the display which best matches the persisted bounds.
+ * @returns Bounds which fit entirely inside the work area.
+ */
+export function fitWindowBoundsToWorkArea(
+  bounds: Rectangle,
+  workArea: Rectangle
+): Rectangle {
+  const width = Math.min(bounds.width, workArea.width);
+  const height = Math.min(bounds.height, workArea.height);
+
+  return {
+    x: Math.max(workArea.x, Math.min(bounds.x, workArea.x + workArea.width - width)),
+    y: Math.max(workArea.y, Math.min(bounds.y, workArea.y + workArea.height - height)),
+    width,
+    height,
+  };
+}
+
+/** Loads and stores the machine-local state of the settings window. */
+export class SettingsWindowStateStore {
+  /** The absolute path of the state file. */
+  public readonly filePath: string;
+
+  constructor(directory: string) {
+    this.filePath = path.join(directory, 'settings-window-state.json');
+  }
+
+  /**
+   * Loads the state from disk. Missing or invalid files fall back to defaults so that UI
+   * state can never prevent Kando from starting.
+   *
+   * @returns The validated settings-window state.
+   */
+  public load(): SettingsWindowState {
+    try {
+      return SETTINGS_WINDOW_STATE_SCHEMA.parse(fs.readJSONSync(this.filePath));
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.error('Failed to load settings-window state:', error);
+      }
+
+      return SETTINGS_WINDOW_STATE_SCHEMA.parse({});
+    }
+  }
+
+  /**
+   * Persists the state to disk. A failure is logged but deliberately kept non-fatal since
+   * window geometry is optional UI state.
+   *
+   * @param state The settings-window state to persist.
+   */
+  public save(state: SettingsWindowState) {
+    try {
+      fs.ensureDirSync(path.dirname(this.filePath));
+      fs.writeJSONSync(this.filePath, SETTINGS_WINDOW_STATE_SCHEMA.parse(state), {
+        spaces: 2,
+      });
+    } catch (error) {
+      console.error('Failed to save settings-window state:', error);
+    }
+  }
+}

--- a/src/settings-renderer/components/App.tsx
+++ b/src/settings-renderer/components/App.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from 'react-tooltip';
 import MouseTrap from 'mousetrap';
 import classNames from 'classnames/bind';
 
+import type { SettingsWindowSidebarWidths } from '../../common';
 import { useGeneralSetting, useMenuSettings } from '../state';
 import {
   AboutDialog,
@@ -41,6 +42,7 @@ const cx = classNames.bind(classes);
 export default function App() {
   const [settingsWindowColorScheme] = useGeneralSetting('settingsWindowColorScheme');
   const [settingsWindowFlavor] = useGeneralSetting('settingsWindowFlavor');
+  const [sidebarWidths, setSidebarWidths] = React.useState<SettingsWindowSidebarWidths>();
 
   // Bind global undo/redo shortcuts.
   React.useEffect(() => {
@@ -73,10 +75,40 @@ export default function App() {
     };
   }, [settingsWindowColorScheme]);
 
-  // Notify the main process that our app is ready to be displayed.
+  // Restore the sidebar widths before notifying the main process that the window can be
+  // displayed. This prevents the default widths from flashing briefly during startup.
   React.useEffect(() => {
-    window.settingsAPI.settingsWindowReady();
+    let active = true;
+
+    void window.settingsAPI
+      .getSidebarWidths()
+      .catch((error) => {
+        console.error('Failed to load settings window sidebar widths:', error);
+        return {};
+      })
+      .then((widths) => {
+        if (active) {
+          setSidebarWidths(widths);
+          window.settingsAPI.settingsWindowReady();
+        }
+      });
+
+    return () => {
+      active = false;
+    };
   }, []);
+
+  const onLeftSidebarWidthChanged = React.useCallback((width: number) => {
+    window.settingsAPI.setSidebarWidth('left', width);
+  }, []);
+
+  const onRightSidebarWidthChanged = React.useCallback((width: number) => {
+    window.settingsAPI.setSidebarWidth('right', width);
+  }, []);
+
+  if (sidebarWidths === undefined) {
+    return null;
+  }
 
   return (
     <>
@@ -90,7 +122,11 @@ export default function App() {
           sakuraDarkFlavor: settingsWindowFlavor === 'sakura-dark',
           sakuraSystemFlavor: settingsWindowFlavor === 'sakura-system',
         })}>
-        <Sidebar mainDirection="row" position="left">
+        <Sidebar
+          initialWidth={sidebarWidths.left}
+          mainDirection="row"
+          position="left"
+          onWidthChanged={onLeftSidebarWidthChanged}>
           <CollectionList />
           <MenuList />
         </Sidebar>
@@ -102,7 +138,11 @@ export default function App() {
           <MenuPreview />
           <PreviewFooter />
         </div>
-        <Sidebar mainDirection="column" position="right">
+        <Sidebar
+          initialWidth={sidebarWidths.right}
+          mainDirection="column"
+          position="right"
+          onWidthChanged={onRightSidebarWidthChanged}>
           <Properties />
         </Sidebar>
         <GeneralSettingsDialog />

--- a/src/settings-renderer/components/common/Sidebar.tsx
+++ b/src/settings-renderer/components/common/Sidebar.tsx
@@ -21,6 +21,12 @@ type Props = {
 
   /** Content to display in the main area of the sidebar. */
   readonly children: React.ReactNode;
+
+  /** The width restored from the machine-local settings window state. */
+  readonly initialWidth?: number;
+
+  /** Called after the user has finished resizing the sidebar. */
+  readonly onWidthChanged?: (width: number) => void;
 };
 
 /**
@@ -34,11 +40,12 @@ type Props = {
 export default function Sidebar(props: Props) {
   const resizer = React.useRef<HTMLDivElement>(null);
   const sidebar = React.useRef<HTMLDivElement>(null);
+  const { position, onWidthChanged } = props;
 
   React.useEffect(() => {
     // Function to handle the resizing of the sidebar.
     const resize = (e: MouseEvent) => {
-      if (props.position === 'left') {
+      if (position === 'left') {
         sidebar.current.style.width = e.clientX + 'px';
       } else {
         sidebar.current.style.width = window.innerWidth - e.clientX + 'px';
@@ -51,18 +58,28 @@ export default function Sidebar(props: Props) {
       document.removeEventListener('mousemove', resize);
       document.removeEventListener('mouseup', stopResize);
       document.body.style.cursor = '';
+
+      if (sidebar.current) {
+        onWidthChanged?.(sidebar.current.getBoundingClientRect().width);
+      }
     };
 
-    // Add event listeners for the resizer. This is done in a useEffect hook to ensure
-    // that the DOM elements are available when the script is executed.
-    if (resizer && sidebar) {
-      resizer.current.addEventListener('mousedown', function () {
-        document.addEventListener('mousemove', resize);
-        document.addEventListener('mouseup', stopResize);
-        document.body.style.cursor = 'col-resize';
-      });
-    }
-  }, [props.position]);
+    const startResize = () => {
+      document.addEventListener('mousemove', resize);
+      document.addEventListener('mouseup', stopResize);
+      document.body.style.cursor = 'col-resize';
+    };
+
+    const resizerElement = resizer.current;
+    resizerElement?.addEventListener('mousedown', startResize);
+
+    return () => {
+      resizerElement?.removeEventListener('mousedown', startResize);
+      document.removeEventListener('mousemove', resize);
+      document.removeEventListener('mouseup', stopResize);
+      document.body.style.cursor = '';
+    };
+  }, [position, onWidthChanged]);
 
   const positionClass = props.position === 'left' ? classes.left : classes.right;
   const directionClass = props.mainDirection === 'row' ? classes.row : classes.column;
@@ -72,7 +89,10 @@ export default function Sidebar(props: Props) {
     <>
       {/* Render the resizer on the left if the sidebar is on the right. */}
       {props.position === 'right' && <div ref={resizer} className={resizerClass} />}
-      <div ref={sidebar} className={classes.sidebar + ' ' + directionClass}>
+      <div
+        ref={sidebar}
+        className={classes.sidebar + ' ' + directionClass}
+        style={{ width: props.initialWidth }}>
         {props.children}
       </div>
       {/* Render the resizer on the right if the sidebar is on the left. */}

--- a/src/settings-renderer/settings-window-api.ts
+++ b/src/settings-renderer/settings-window-api.ts
@@ -20,6 +20,7 @@ import {
   SystemInfo,
   AppDescription,
   LevelProgress,
+  SettingsWindowSidebarWidths,
 } from '../common';
 import { IPCMenuManager } from './utils/ipc-menu-manager';
 
@@ -55,6 +56,16 @@ export const SETTINGS_WINDOW_API = {
   /** Returns some information about the current system. */
   getSystemInfo: (): Promise<SystemInfo> => {
     return ipcRenderer.invoke('settings-window.get-system-info');
+  },
+
+  /** Returns the persisted widths of the resizable settings window sidebars. */
+  getSidebarWidths: (): Promise<SettingsWindowSidebarWidths> => {
+    return ipcRenderer.invoke('settings-window.get-sidebar-widths');
+  },
+
+  /** Persists the width of one resizable settings window sidebar. */
+  setSidebarWidth: (position: 'left' | 'right', width: number) => {
+    ipcRenderer.send('settings-window.set-sidebar-width', position, width);
   },
 
   /** Returns the index of the last opened menu. */

--- a/test/settings-window-state.spec.ts
+++ b/test/settings-window-state.spec.ts
@@ -1,0 +1,95 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//   _  _ ____ _  _ ___  ____                                                           //
+//   |_/  |__| |\ | |  \ |  |    This file belongs to Kando, the cross-platform         //
+//   | \_ |  | | \| |__/ |__|    pie menu. Read more on github.com/kando-menu/kando     //
+//                                                                                      //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Morax <james20081204@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { expect } from 'chai';
+
+import {
+  SettingsWindowStateStore,
+  fitWindowBoundsToWorkArea,
+} from '../src/main/settings/settings-window-state';
+
+describe('SettingsWindowStateStore', () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'kando-window-state-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(directory);
+  });
+
+  it('returns defaults when the state file does not exist', () => {
+    const store = new SettingsWindowStateStore(directory);
+
+    expect(store.load()).to.deep.equal({ maximized: false });
+  });
+
+  it('persists and reloads window state', () => {
+    const store = new SettingsWindowStateStore(directory);
+    const state = {
+      bounds: { x: -1200, y: 80, width: 1100, height: 760 },
+      maximized: true,
+    };
+
+    store.save(state);
+
+    expect(fs.readJSONSync(store.filePath)).to.deep.equal(state);
+    expect(new SettingsWindowStateStore(directory).load()).to.deep.equal(state);
+  });
+
+  it('returns defaults when the state file is invalid', () => {
+    const store = new SettingsWindowStateStore(directory);
+    fs.writeJSONSync(store.filePath, {
+      bounds: { x: 0, y: 0, width: -1, height: 700 },
+      maximized: 'yes',
+    });
+
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      expect(store.load()).to.deep.equal({ maximized: false });
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});
+
+describe('fitWindowBoundsToWorkArea', () => {
+  it('keeps bounds that already fit within the work area', () => {
+    const bounds = { x: -1800, y: 100, width: 1100, height: 760 };
+    const workArea = { x: -1920, y: 0, width: 1920, height: 1080 };
+
+    expect(fitWindowBoundsToWorkArea(bounds, workArea)).to.deep.equal(bounds);
+  });
+
+  it('moves off-screen bounds into the work area', () => {
+    const bounds = { x: 2500, y: -500, width: 1200, height: 800 };
+    const workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+
+    expect(fitWindowBoundsToWorkArea(bounds, workArea)).to.deep.equal({
+      x: 720,
+      y: 0,
+      width: 1200,
+      height: 800,
+    });
+  });
+
+  it('shrinks oversized bounds to the work area', () => {
+    const bounds = { x: -2500, y: -200, width: 2400, height: 1200 };
+    const workArea = { x: -1920, y: 0, width: 1920, height: 1040 };
+
+    expect(fitWindowBoundsToWorkArea(bounds, workArea)).to.deep.equal(workArea);
+  });
+});

--- a/test/settings-window-state.spec.ts
+++ b/test/settings-window-state.spec.ts
@@ -40,6 +40,7 @@ describe('SettingsWindowStateStore', () => {
     const state = {
       bounds: { x: -1200, y: 80, width: 1100, height: 760 },
       maximized: true,
+      sidebarWidths: { left: 320, right: 410 },
     };
 
     store.save(state);
@@ -53,6 +54,23 @@ describe('SettingsWindowStateStore', () => {
     fs.writeJSONSync(store.filePath, {
       bounds: { x: 0, y: 0, width: -1, height: 700 },
       maximized: 'yes',
+    });
+
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      expect(store.load()).to.deep.equal({ maximized: false });
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  it('rejects invalid persisted sidebar widths', () => {
+    const store = new SettingsWindowStateStore(directory);
+    fs.writeJSONSync(store.filePath, {
+      maximized: false,
+      sidebarWidths: { left: -10 },
     });
 
     const originalConsoleError = console.error;


### PR DESCRIPTION
## Description

This stores the settings window's normal bounds, maximized state, and left/right sidebar widths in a separate machine-local `settings-window-state.json` file. Restored window bounds are fitted to the best matching display's current work area, so removing a monitor or changing its resolution cannot leave the settings window off-screen. Missing or invalid state still uses the existing 1350 x 900 window and 370px sidebar defaults.

Sidebar widths are loaded before the settings window is displayed, avoiding a flash of the default layout, and persisted when a resize finishes. Window bounds are saved both when the settings window closes normally and before Kando destroys it during application shutdown.

Focused tests cover state validation, persistence (including sidebar widths), multi-monitor coordinates, off-screen restoration, and oversized windows.

## Testing

- `npm test` (67 passing)
- `npm run tscheck`
- `npm run lint`
- `npm run prettier`

Closes #1462
