### PR TITLE
Keyboard-selection feedback

### DIFF
--- a/assets/menu-themes/default/theme.css
+++ b/assets/menu-themes/default/theme.css
@@ -102,7 +102,7 @@
   &.parent.hovered.clicked>.icon-layer,
   &.child.hovered.clicked>.icon-layer,
   &.active.hovered.clicked>.icon-layer {
-    transform: scale(0.95);
+    transform: scale(0.9);
   }
 
   /* Show the icons of the center, parent and child items. */

--- a/assets/menu-themes/rainbow-labels/theme.css
+++ b/assets/menu-themes/rainbow-labels/theme.css
@@ -158,6 +158,15 @@
     transform: scale(0.95);
   }
 
+  &.hovered.clicked>.label-layer {
+    border-color: white;
+    box-shadow: 0 0 20px hsla(var(--angle), 80%, 80%, 0.4) inset;
+  }
+
+  &.hovered.clicked>.icon-layer {
+    background-color: white;
+  }
+
   /* We disable any transition for dragged submenu items. */
   &.dragged.type-submenu {
     transition: none;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,7 @@ The [Unreleased] section contains changes which are not released yet. If you wan
 - The position of the delete-menu-item and duplicate-menu-item buttons in the settings dialog. They are now shown next to selected menu items in the preview area.
 - The position of the menu context buttons (duplicate, export, delete). They are not shown in a Kando custom menu anymore. 
 - What happens when you select a submenu in the menu preview in the settings: before, the submenu would open immediately. Now, it will be selected just as other menu items. To edit its content, you have to either double-click it or use the tiny edit button which appears when you select the submenu.
+- Workflows are now executed on key-up instead of key-down. This improves the visual feedback of the menu as it's not instantly closed when you select a menu item. It also resolves some issues where actions were not reliably executed when a key was still held down.
 - The default fade-in and fade-out times of the menu. They are now 75ms and 100ms respectively. This makes the menu feel snappier and more responsive.
 - If the system supports it, Kando menus will now be shown on all workspaces.
 - Systems using the `zh-TW` locale will now fall back to `zh-Hant` before using English strings. Thanks to [@ClixTW](https://github.com/ClixTW) for this contribution!

--- a/src/menu-renderer/menu.ts
+++ b/src/menu-renderer/menu.ts
@@ -453,18 +453,12 @@ export class Menu extends (EventEmitter as new () => TypedEventEmitter<MenuEvent
       }
     };
 
-    this.pointerInput.onCloseMenu(onCloseMenu);
-    this.gamepadInput.onCloseMenu(onCloseMenu);
-
-    this.pointerInput.onUpdateState(onUpdateState);
-    this.gamepadInput.onUpdateState(onUpdateState);
-
-    this.pointerInput.onSelection(onSelection);
-    this.gamepadInput.onSelection(onSelection);
-
-    // Handle keyboard events for quick selection and going back to the parent item.
-    document.addEventListener('keydown', (event) => {
+    const onKeyEvent = (event: KeyboardEvent) => {
       if (this.container.classList.contains('hidden')) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
         return;
       }
 
@@ -474,7 +468,8 @@ export class Menu extends (EventEmitter as new () => TypedEventEmitter<MenuEvent
       if (!anyModifierPressed) {
         const eventKey = KeyMapper.getName(event).toLocaleLowerCase();
 
-        // Then we check whether the center-click-workflow of the center item got triggered.
+        // Then we check whether the center-click-workflow of the center item got
+        // triggered. On key-down, we hover the center item and on key-up, we select it.
         if (
           (this.centerItem.type === 'submenu' || this.centerItem.type === 'root') &&
           this.centerItem.activateWorkflow?.quickSelectKey
@@ -483,10 +478,14 @@ export class Menu extends (EventEmitter as new () => TypedEventEmitter<MenuEvent
             this.centerItem.activateWorkflow.quickSelectKey.toLocaleLowerCase() ===
             eventKey
           ) {
-            this.emitItemInteractionEvent(
-              MenuInteractionType.eActivateMenu,
-              this.centerItem.renderData.path
-            );
+            if (event.type === 'keydown') {
+              this.hoverItem(this.centerItem);
+            } else {
+              this.emitItemInteractionEvent(
+                MenuInteractionType.eActivateMenu,
+                this.centerItem.renderData.path
+              );
+            }
             return;
           }
         }
@@ -508,15 +507,22 @@ export class Menu extends (EventEmitter as new () => TypedEventEmitter<MenuEvent
             }
 
             if (selectionKeys.includes(eventKey)) {
-              if (child.type === 'submenu') {
-                this.emitItemInteractionEvent(
-                  MenuInteractionType.eOpenSubmenu,
-                  child.renderData.path
-                );
-                this.openSubmenu(child, this.getCenterItemPosition());
-              } else {
-                this.emitSelectionEvent(child, SelectionSource.eKeyboard);
+              if (event.type === 'keydown') {
+                this.latestInput.button = ButtonState.eClicked;
                 this.hoverAngle(child.renderData.computedAngle);
+              } else {
+                if (child.type === 'submenu') {
+                  this.emitItemInteractionEvent(
+                    MenuInteractionType.eOpenSubmenu,
+                    child.renderData.path
+                  );
+                  this.openSubmenu(child, this.getCenterItemPosition());
+                } else {
+                  this.emitSelectionEvent(child, SelectionSource.eKeyboard);
+                }
+
+                this.latestInput.button = ButtonState.eReleased;
+                this.redraw();
               }
               return;
             }
@@ -536,61 +542,68 @@ export class Menu extends (EventEmitter as new () => TypedEventEmitter<MenuEvent
             }
           }
         }
-      }
 
-      if (
-        event.key === 'ArrowLeft' ||
-        event.key === 'ArrowUp' ||
-        event.key === 'ArrowRight' ||
-        event.key === 'ArrowDown'
-      ) {
-        this.changeHoveredItem(event.key);
-        return;
-      }
-
-      if (event.key === 'Enter') {
-        if (this.hoveredItem) {
-          if (this.hoveredItem === this.centerItem) {
-            this.emitItemInteractionEvent(
-              MenuInteractionType.eActivateMenu,
-              this.hoveredItem.renderData.path
-            );
-          } else if (this.hoveredItem === this.centerItem.renderData.parent) {
-            this.selectParent();
-          } else if (this.hoveredItem.type === 'submenu') {
-            this.emitItemInteractionEvent(
-              MenuInteractionType.eOpenSubmenu,
-              this.hoveredItem.renderData.path
-            );
-            this.openSubmenu(this.hoveredItem);
-          } else {
-            this.emitSelectionEvent(this.hoveredItem, SelectionSource.eKeyboard);
+        if (event.type === 'keydown') {
+          if (
+            event.key === 'ArrowLeft' ||
+            event.key === 'ArrowUp' ||
+            event.key === 'ArrowRight' ||
+            event.key === 'ArrowDown'
+          ) {
+            this.changeHoveredItem(event.key);
+            return;
           }
+        }
 
-          return;
+        if (event.key === 'Enter') {
+          if (event.type === 'keydown') {
+            this.latestInput.button = ButtonState.eClicked;
+            this.redraw();
+          } else {
+            if (this.hoveredItem) {
+              if (this.hoveredItem === this.centerItem) {
+                this.emitItemInteractionEvent(
+                  MenuInteractionType.eActivateMenu,
+                  this.hoveredItem.renderData.path
+                );
+              } else if (this.hoveredItem === this.centerItem.renderData.parent) {
+                this.selectParent();
+              } else if (this.hoveredItem.type === 'submenu') {
+                this.emitItemInteractionEvent(
+                  MenuInteractionType.eOpenSubmenu,
+                  this.hoveredItem.renderData.path
+                );
+                this.openSubmenu(this.hoveredItem);
+              } else {
+                this.emitSelectionEvent(this.hoveredItem, SelectionSource.eKeyboard);
+              }
+
+              this.latestInput.button = ButtonState.eReleased;
+              this.redraw();
+            }
+            return;
+          }
         }
       }
 
-      if (event.key !== 'Escape') {
+      if (event.type === 'keydown') {
         this.pointerInput.onKeyDownEvent();
+      } else {
+        this.pointerInput.onKeyUpEvent(event);
       }
-    });
+    };
 
-    // If the last modifier is released while a menu item is dragged around, we select it.
-    // This enables selections in "Turbo-Mode", where items can be selected with mouse
-    // movements without pressing the left mouse button but by holding a keyboard key
-    // instead.
-    document.addEventListener('keyup', (event) => {
-      if (this.container.classList.contains('hidden')) {
-        return;
-      }
+    this.pointerInput.onCloseMenu(onCloseMenu);
+    this.gamepadInput.onCloseMenu(onCloseMenu);
 
-      if (event.key === 'Escape') {
-        return;
-      }
+    this.pointerInput.onUpdateState(onUpdateState);
+    this.gamepadInput.onUpdateState(onUpdateState);
 
-      this.pointerInput.onKeyUpEvent(event);
-    });
+    this.pointerInput.onSelection(onSelection);
+    this.gamepadInput.onSelection(onSelection);
+
+    document.addEventListener('keydown', onKeyEvent);
+    document.addEventListener('keyup', onKeyEvent);
 
     this.container.addEventListener('pointerdown', (e) => {
       this.pointerInput.onPointerDownEvent(e);


### PR DESCRIPTION
This makes sure that the `.clicked` CSS is also applied to menu items when selecting them with the keyboard. This makes the selection feel more responsive, especially when the menu is not closed after a selection.

It also makes the selection effect of the default themes a bit stronger. Resolves #1480.