### PR TITLE
Fix macOS App Picker: missing apps and unrelated search results

### DIFF
--- a/src/main/backends/macos/native/Native.mm
+++ b/src/main/backends/macos/native/Native.mm
@@ -29,16 +29,14 @@ Napi::Object processAppAtPath(const Napi::Env& env, NSString* appPath) {
     return Napi::Object();
   }
 
-  // Filter out bundles that are background-only or UI elements (agents/helpers).
+  // Filter out bundles that are pure background processes with no UI at all. Note that
+  // we deliberately do *not* filter out LSUIElement apps: that flag only means "no Dock
+  // icon", not "not user-launchable" — lots of everyday menu-bar-only apps (and Kando
+  // itself) set it, so excluding them hid apps that were actually installed.
   NSDictionary* infoDict = [bundle infoDictionary];
   if (infoDict) {
     NSNumber* lsbg = infoDict[@"LSBackgroundOnly"];
     if (lsbg && [lsbg boolValue]) {
-      return Napi::Object();
-    }
-
-    NSNumber* lsui = infoDict[@"LSUIElement"];
-    if (lsui && [lsui boolValue]) {
       return Napi::Object();
     }
   }
@@ -57,8 +55,12 @@ Napi::Object processAppAtPath(const Napi::Env& env, NSString* appPath) {
 
   NSString* name = [[bundle objectForInfoDictionaryKey:@"CFBundleName"] description];
 
+  // The bundle's file name (e.g. "Safari" for "Safari.app") is what "open -a" expects
+  // and what a file dropped from the Finder is named, so we use it as our id below.
+  NSString* bundleFileName = [[appPath lastPathComponent] stringByDeletingPathExtension];
+
   if (!name) {
-    name = [[appPath lastPathComponent] stringByDeletingPathExtension];
+    name = bundleFileName;
   }
 
   // Create a 64x64 bitmap and draw the icon into it
@@ -89,7 +91,7 @@ Napi::Object processAppAtPath(const Napi::Env& env, NSString* appPath) {
 
       Napi::Object appInfo = Napi::Object::New(env);
       appInfo.Set("name", Napi::String::New(env, name.UTF8String));
-      appInfo.Set("id", Napi::String::New(env, execName.UTF8String));
+      appInfo.Set("id", Napi::String::New(env, bundleFileName.UTF8String));
       appInfo.Set("base64Icon", Napi::String::New(env, base64Icon.UTF8String));
       return appInfo;
     }
@@ -377,12 +379,19 @@ Napi::Value Native::listInstalledApplications(const Napi::CallbackInfo& info) {
   Napi::Array result = Napi::Array::New(env);
 
   @autoreleasepool {
+    // Note: "/System/Library/CoreServices/Applications" is deliberately not listed
+    // separately here — it is a subdirectory of "/System/Library/CoreServices" below,
+    // so the recursive enumerator already visits it. Listing both produced a duplicate
+    // entry (same id, same name) for every app in that folder.
     NSArray<NSString*>* appDirs = @[
       @"/Applications", @"/System/Applications", @"/System/Library/CoreServices",
-       @"/System/Library/CoreServices/Applications",
       [NSHomeDirectory() stringByAppendingPathComponent:@"Applications"],
       [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Applications"]
     ];
+
+    // Guards against the same app bundle being added twice, in case any of the
+    // directories above end up overlapping (e.g. one being a subdirectory of another).
+    NSMutableSet<NSString*>* seenPaths = [NSMutableSet set];
 
     NSFileManager* fm = [NSFileManager defaultManager];
     for (NSString* dir in appDirs) {
@@ -390,10 +399,13 @@ Napi::Value Native::listInstalledApplications(const Napi::CallbackInfo& info) {
       NSString*              file;
       while ((file = [enumerator nextObject])) {
         if ([[file pathExtension] isEqualToString:@"app"]) {
-          NSString*    fullPath = [dir stringByAppendingPathComponent:file];
-          Napi::Object appInfo  = processAppAtPath(env, fullPath);
-          if (!appInfo.IsEmpty()) {
-            result.Set(result.Length(), appInfo);
+          NSString* fullPath = [dir stringByAppendingPathComponent:file];
+          if (![seenPaths containsObject:fullPath]) {
+            [seenPaths addObject:fullPath];
+            Napi::Object appInfo = processAppAtPath(env, fullPath);
+            if (!appInfo.IsEmpty()) {
+              result.Set(result.Length(), appInfo);
+            }
           }
           [enumerator skipDescendants];
         }


### PR DESCRIPTION
## Summary

The macOS installed-apps scan (used by the Run Command action's App Picker) had two bugs:

- It excluded any app with `LSUIElement` set, on the assumption that flag meant "background helper". It actually just means "no Dock icon", so it wrongly hid dozens of everyday menu-bar apps — Docker, Google Drive, Stats, SoundSource, Rectangle Pro, and even Kando itself never showed up in its own App Picker.
- It used the app's internal executable name (`CFBundleExecutable`) as the app's unique `id`. That name is often generic and shared across unrelated apps — every Chrome-generated web-app shortcut uses `app_mode_loader`, for example — so many installed apps collided on the same id. Since the settings UI uses that id as the React list key, colliding ids corrupted the App Picker's rendering, producing search results unrelated to the typed query.

Also removed a redundant directory entry (`/System/Library/CoreServices/Applications` is already a subdirectory of `/System/Library/CoreServices`, which is scanned recursively) that caused every app in that folder to be scanned twice, and added a defensive dedupe by path as a safety net.

## Verification

Compiled the native addon and called `listInstalledApplications()` directly (bypassing the Electron renderer) before and after the fix, on a machine with ~300 installed applications:

- App count went from 226 to 310 (previously-hidden `LSUIElement` apps recovered).
- Id collisions dropped from 20+ affected apps down to a single expected edge case (two distinct, real `Siri.app` bundles that happen to share a display name — the same limitation `open -a` itself has).

Also built and ran the packaged app (`npm run package`) and confirmed in the running App Picker that previously-missing apps (Docker, Google Drive, Stats, etc.) now appear, and that Chrome-generated app shortcuts are searchable and distinguishable.

## Test plan

- [x] Compiled the native addon and diffed `listInstalledApplications()` output before/after the fix
- [x] Built and ran the packaged app; confirmed the App Picker now finds previously-missing apps and search results match the typed query
- [ ] No automated regression test was added — this repo has no existing test infrastructure for the native macOS addon, and its directory scan reads real system paths with no injectable seam for a deterministic, machine-independent test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Disclosure:** This PR — the diagnosis, the code changes, testing, and this description — was written entirely by Claude (Anthropic's AI coding assistant). I noticed the bug while using the app and asked Claude to investigate and fix it; I did not write or review any code myself.
